### PR TITLE
fixed a bug in getResponse.lm

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.4 (?? April 2014)
   * Fixed bug in forecast.tbats() and forecast.bats() when ts.frequency does not match seasonal.periods.
+	* Fixed bug in getResponse.lm() when there's a logged dependent variable.
 
 Version 5.3 (24 March 2014)
   * Unit tests added

--- a/R/getResponse.R
+++ b/R/getResponse.R
@@ -8,7 +8,7 @@ getResponse.default <- function(object,...){
 }
 
 getResponse.lm <- function(object,...) {
-	responsevar <- as.character(formula(object$model))[2]
+	responsevar <- as.character(formula(object))[2]
 	ans <- model.frame(object$model)[,responsevar]
 	return(ans)
 }


### PR DESCRIPTION
There's a little bug in `getResponse.lm()`.

``` s
library(fpp)
creditlog <- data.frame(score=credit$score,
                   log.savings=log(credit$savings+1),
               log.income=log(credit$income+1),
               log.address=log(credit$time.address+1),
               log.employed=log(credit$time.employed+1),
               fte=credit$fte, single=credit$single)
fit <- lm(log(score) ~ log.savings + log.income +
               log.address + log.employed, data=creditlog[1:480, ])
fcasts <- forecast(fit, newdata = creditlog[481:500, ], lambda = 0)  
# Error due to getResponse
```
