### PR TITLE
Update forecast.varest.R

### DIFF
--- a/R/forecast.varest.R
+++ b/R/forecast.varest.R
@@ -13,7 +13,7 @@ forecast.varest <- function(object, h=10, level=c(80,95), fan=FALSE, ...)
 	out$mean <- out$lower <- out$upper <- vector("list",object$K)
 	for(i in 1:(length(level)))
 	{
-		pr <- predict(object, n.ahead=h, ci=level[i]/100)
+		pr <- predict(object, n.ahead=h, ci=level[i]/100, ...)
 		for(j in 1:object$K)
 		{
 			if(i==1)


### PR DESCRIPTION
When running a VAR with exogenous variables, one needs to provide the `dumvar`argument to `predict.varest`. Therefore, I just added the `...` to the `predict` function so it can pass the `dumvar` parameter (and other parameters as well) to `predict.varest`.