### PR TITLE
Test accuracy for arima, ets, lm, and tbats objects

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -176,7 +176,7 @@ trainingaccuracy <- function(f,test,d, D)
 
 accuracy <- function(f,x,test=NULL,d=NULL,D=NULL)
 {
-  if(!any(is.element(class(f), c("mforecast","forecast","ts","integer","numeric","Arima","ets","lm"))))
+  if(!any(is.element(class(f), c("mforecast","forecast","ts","integer","numeric","Arima","ets","lm","bats","tbats"))))
     stop("First argument should be a forecast object or a time series.")
   if(is.element("mforecast", class(f)))
     return(accuracy.mforecast(f,x,test,d,D))

--- a/inst/tests/test-accurary.R
+++ b/inst/tests/test-accurary.R
@@ -34,10 +34,5 @@ if(require(fpp) & require(testthat))
 	accuracylm <- accuracy(fitlm)[1, "RMSE"]
 	accuracylmsim <- accuracy(lm(simulate(fitlm, seed = 123)[, 1] ~ month))[1, "RMSE"]
 	expect_more_than(accuracylm, accuracylmsim)
-	# Test tbats
-	fittbats <- tbats(vn[, "Sydney"])
-	accuracytbats <- accuracy(fittbats)
-	accuracytbatssim <- accuracy(tbats(simulate(fittbats, see = 123)))[1, "RMSE"]
-	expect_more_than(accuracytbats, accuracytbatsssim)
 	})
 }


### PR DESCRIPTION
Add more unit tests for ```accuracy()```. Accuracy from the fitted models should be worse than accuracy of a model fit on simulated data from the selected model specification.