### PR TITLE
Give informative error when using previous model with mismatched xreg

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -549,13 +549,6 @@ Arima <- function(x, order=c(0, 0, 0),
 
   if(!is.null(model))
   {
-    if(!is.null(model$xreg))
-    {
-      if(is.null(xreg))
-        stop("No regressors provided")
-      if(ncol(xreg) != ncol(model$xreg))
-        stop("Number of regressors does not match fitted model")
-    }
     tmp <- arima2(x,model,xreg=xreg,method=method)
     xreg <- tmp$xreg
   }
@@ -606,6 +599,14 @@ arima2 <- function (x, model, xreg, method)
         xreg <- as.matrix(data.frame(drift=newxreg))
       }
       use.xreg <- TRUE
+    }
+
+    if(!is.null(model$xreg))
+    {
+      if(is.null(xreg))
+        stop("No regressors provided")
+      if(ncol(xreg) != ncol(model$xreg))
+        stop("Number of regressors does not match fitted model")
     }
 
     if(model$arma[5]>1 & sum(abs(model$arma[c(3,4,7)]))>0) # Seasonal model

--- a/R/arima.R
+++ b/R/arima.R
@@ -477,7 +477,7 @@ fitted.Arima <- function(object, biasadj = FALSE, ...)
   if(is.null(object$lambda)){
     return(x - object$residuals)
   }
-  else{    
+  else{
     if(biasadj){
       return(InvBoxCoxf(x = (BoxCox(x,object$lambda) - object$residuals), fvar = var(object$residuals), lambda = object$lambda))
     }
@@ -492,7 +492,7 @@ fitted.Arima <- function(object, biasadj = FALSE, ...)
 # Also allows refitting to new data
 # and drift terms to be included.
 Arima <- function(x, order=c(0, 0, 0),
-      seasonal=c(0, 0, 0), 
+      seasonal=c(0, 0, 0),
       xreg=NULL, include.mean=TRUE, include.drift=FALSE, include.constant, lambda=model$lambda,
     transform.pars=TRUE,
       fixed=NULL, init=NULL, method=c("CSS-ML", "ML", "CSS"),
@@ -549,6 +549,13 @@ Arima <- function(x, order=c(0, 0, 0),
 
   if(!is.null(model))
   {
+    if(!is.null(model$xreg))
+    {
+      if(is.null(xreg))
+        stop("No regressors provided")
+      if(ncol(xreg) != ncol(model$xreg))
+        stop("Number of regressors does not match fitted model")
+    }
     tmp <- arima2(x,model,xreg=xreg,method=method)
     xreg <- tmp$xreg
   }
@@ -734,7 +741,7 @@ print.ARIMA <- function (x, digits=max(3, getOption("digits") - 3), se=TRUE,
 #     else return(pred)
 # }
 
-arimaorder <- function (object) 
+arimaorder <- function (object)
 {
 	if(is.element("Arima",class(object)))
 	{
@@ -747,7 +754,7 @@ arimaorder <- function (object)
 	}
 	else if(is.element("ar",class(object)))
 	{
-		return(c(object$order,0,0))	
+		return(c(object$order,0,0))
 	}
 	else if(is.element("fracdiff",class(object)))
 	{


### PR DESCRIPTION
When using a previously fitted model in `Arima` with a mismatched `xreg` (either missing or wrong size),  one gets this error message which is not very informative:
```
Error in stats::arima(x = x, order = order, seasonal = seasonal, xreg = xreg,  : 
  wrong length for 'fixed'
```
I added the same checks & error messages used in `forecast.Arima`. The only exception is that I omitted `getxreg(object)`, is this extra call necessary? should it be included instead of just `object$xreg`?

Trailing whitespaces were also deleted (I have emacs set up to automatically do that... figured you wouldn't mind?).

Here's some sample code to see the errors:
```
x <- rnorm(100)
xreg <- matrix(rnorm(200), ncol = 2)
fit <- Arima(x, order = c(1, 0, 0), xreg = xreg)
##
## Correct input - no error
x2 <- rnorm(100)
xreg2 <- matrix(rnorm(200), ncol = 2)
fit2 <- Arima(x2, xreg = xreg2, model = fit)
##
## Missing rows in xreg - useful error from stats::arima
x2 <- rnorm(100)
xreg2 <- matrix(rnorm(100), ncol = 2)
fit2 <- Arima(x2, xreg = xreg2, model = fit)
##
## Wrong number of columns in xreg - unclear error from stats::arima
xreg3 <- matrix(rnorm(100), ncol = 1)
fit2 <- Arima(x2, xreg = xreg3, model = fit)
##
## Missing xreg completely - unclear error from stats::arima
fit2 <- Arima(x2, model = fit)
```