### PR TITLE
Fix to NA induced bug in nnetar

### DIFF
--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -97,7 +97,7 @@ nnetar <- function(x, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, scale.in
   if(!is.null(lambda))
     fits <- InvBoxCox(fits,lambda)
   out$fitted <- ts(numeric(length(out$x)))
-  out$fitted[j] <- fits
+  out$fitted[c(rep(TRUE, maxlag), j)] <- fits
   tsp(out$fitted) <- tsp(out$x)
   out$residuals <- out$x - out$fitted
   out$lags <- lags

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -7,6 +7,9 @@
 
 nnetar <- function(x, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, scale.inputs=TRUE, ...)
 {
+  # Check for NAs in x
+  if (any(is.na(x)))
+    warning("Missing values in x, omitting rows")
   # Transform data
   if(!is.null(lambda))
     xx <- BoxCox(x,lambda)
@@ -29,7 +32,10 @@ nnetar <- function(x, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, scale.in
     xreg <- as.matrix(xreg)
     if(length(x) != nrow(xreg))
       stop("Number of rows in xreg does not match series length")
-    ## Scale xreg
+    # Check for NAs in xreg
+    if(any(is.na(xreg)))
+      warning("Missing values in xreg, omitting rows")
+    # Scale xreg
     if(scale.inputs)
     {
       xxreg <- scale(xreg, center = TRUE, scale = TRUE)

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -96,7 +96,7 @@ nnetar <- function(x, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, scale.in
   fits <- ts(fits)
   if(!is.null(lambda))
     fits <- InvBoxCox(fits,lambda)
-  out$fitted <- ts(numeric(length(out$x)))
+  out$fitted <- ts(rep(NA, length(out$x)))
   out$fitted[c(rep(TRUE, maxlag), j)] <- fits
   tsp(out$fitted) <- tsp(out$x)
   out$residuals <- out$x - out$fitted

--- a/man/nnetar.Rd
+++ b/man/nnetar.Rd
@@ -24,7 +24,7 @@
 
 \description{Feed-forward neural networks with a single hidden layer and lagged inputs for forecasting univariate time series.}
 
-\details{A feed-forward neural network is fitted with lagged values of \code{x} as inputs and a single hidden layer with \code{size} nodes. The inputs are for lags 1 to \code{p}, and lags \code{m} to \code{mP} where \code{m=frequency(x)}. If there are missing values in \code{x} or \code{xreg}), the corresponding rows (and any others which depend on them as lags) are omitted from the fit and return a value of zero. A total of \code{repeats} networks are fitted, each with random starting weights. These are then averaged when computing forecasts. The network is trained for one-step forecasting. Multi-step forecasts are computed recursively. The fitted model is called an NNAR(p,P) model and is analogous to an ARIMA(p,0,0)(P,0,0) model but with nonlinear functions.
+\details{A feed-forward neural network is fitted with lagged values of \code{x} as inputs and a single hidden layer with \code{size} nodes. The inputs are for lags 1 to \code{p}, and lags \code{m} to \code{mP} where \code{m=frequency(x)}. If there are missing values in \code{x} or \code{xreg}), the corresponding rows (and any others which depend on them as lags) are omitted from the fit. A total of \code{repeats} networks are fitted, each with random starting weights. These are then averaged when computing forecasts. The network is trained for one-step forecasting. Multi-step forecasts are computed recursively. The fitted model is called an NNAR(p,P) model and is analogous to an ARIMA(p,0,0)(P,0,0) model but with nonlinear functions.
 }
 
 


### PR DESCRIPTION
I noticed a bug in `nnetar` where when NAs were present, sometimes the fitted values were not aligned correctly with the original series. 
This is caused by line 100
```
  out$fitted[j] <- fits
```
since `j` is not always the same length as `fits` in which case it often gets recycled instead of giving an error.

I also added some warnings when there are NAs, and modified the fitted series to output `NA` instead of `0` for values with were ignored due to being missing.

To test try:
- Here one would expect a single NA in the first value, which is correct
```
x <- ts(rnorm(15))
nn_fit <- nnetar(x, p=1)
nn_fit$fitted
```
- Here we would expect the first value to be missing due to the lag, and the second and third values to be missing (being the original NA and the value which has it as a lag).
```
x <- ts(rnorm(15))
x[2] <- NA
nn_fit <- nnetar(x, p=1)
nn_fit$fitted
```
- This warning is given, and one can see that the last value of the series is incorrectly missing (due to `j` being recycled as an index)
```
Warning message:
In NextMethod("[<-") :
  number of items to replace is not a multiple of replacement length
```
- An even more insidious error occurs here, as the result is incorrect but no warning occurs. The first element should be missing due to the lag, and elements 12 and 13 due to the original NA. Instead, 1, 11, and 12 are missing.
``` 
x <- ts(rnorm(15))
x[12] <- NA
nn_fit <- nnetar(x, p=1)
nn_fit$fitted
```