### PR TITLE
Add data checks to nnetar() from #254

### DIFF
--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -12,9 +12,22 @@ nnetar <- function(x, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   {
     # Use previously fitted model
     useoldmodel <- TRUE
-    # Check for conflicts between new and old data
+    # Check for conflicts between new and old data:
+    # Check model class
     if (!is.nnetar(model))
       stop("Model must be a nnetar object")
+    # Check new data
+    m <- frequency(model$x)
+    minlength <- max(c(model$p, model$P*m))
+    if (length(x) < minlength)
+      stop(paste("Series must be at least of length", minlength, "to use fitted model"))
+    x <- as.ts(x)
+    if (tsp(x)[3] != m)
+    {
+      warning(paste("Data frequency doesn't match fitted model, coercing to frequency =", m))
+      x <- ts(x, frequency=m)
+    }
+    # Check xreg
     if (!is.null(model$xreg))
     {
       if (is.null(xreg))


### PR DESCRIPTION
After thinking a bit more about #254 I think this should be sufficient to address the most common scenarios. 

- Stop with error message if series is too short
- If time series frequency doesn't match between old data and new, give a warning but continue fitting after coercing the new series to the old frequency.

Feel free to close #254 if you agree that this should work for now. 

Also, if you decide to merge both this and #253, I can rebase one of the branches to avoid any merge conflicts.