### PR TITLE
tsdiag: Change acf to Acf

### DIFF
--- a/R/tsdiag.R
+++ b/R/tsdiag.R
@@ -7,7 +7,7 @@ tsdiag.ets <- function (object, gof.lag = 10, ...)
     plot(stdres, type = "h", main = "Standardized Residuals", 
         ylab = "")
     abline(h = 0)
-    acf(object$residuals, plot = TRUE, main = "ACF of Residuals", 
+    Acf(object$residuals, plot = TRUE, main = "ACF of Residuals", 
         na.action = na.pass)
     nlag <- gof.lag
     pval <- numeric(nlag)


### PR DESCRIPTION
The 0th lag in the acf function creates a scaling issue that makes the ACF plot impossible to view.
The Acf function from this forecast package ignores the 0th lag and makes for a much better plot.