### PR TITLE
Keep tsp properties when slicing ts object

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -48,7 +48,7 @@ subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL, ...
   else
     if(min(season) < 1L | max(season) > frequency(x))
       stop(paste("Seasons must be between 1 and", frequency(x)))
-  
+
   start <- utils::head(time(x)[is.element(cycle(x), season)],1)
   if("mts" %in% class(x)){
     x <- subset.matrix(x, is.element(cycle(x), season))
@@ -57,4 +57,26 @@ subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL, ...
     x <- subset.default(x, is.element(cycle(x), season))
   }
     return(ts(x, frequency=length(season), start=start))
+}
+
+
+## Keep tsp properties when extracting with consecutive indices
+"[.ts" <- function (x, i, j, drop = TRUE)
+{
+  y <- NextMethod("[")
+  if (missing(i))
+  {
+    ts(y, start = start(x), frequency = frequency(x))
+  }
+  else
+  {
+    consec <- all(diff(i)==1)
+    if (isTRUE(consec) && !is.logical(i))
+    {
+      xtime <- as.vector(time(x))
+      ts(y, start=xtime[min(i)], end=xtime[max(i)], frequency = frequency(x))
+    }
+    else
+      y
+  }
 }

--- a/R/subset.R
+++ b/R/subset.R
@@ -71,10 +71,12 @@ subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL, ...
   else
   {
     consec <- all(diff(i)==1)
-    if (isTRUE(consec) && !is.logical(i))
+    l <- length(i)
+    numseq <- !is.logical(i) && isTRUE(l>1)
+    if (isTRUE(consec) && isTRUE(numseq))
     {
-      xtime <- as.vector(time(x))
-      ts(y, start=xtime[min(i)], end=xtime[max(i)], frequency = frequency(x))
+      xtime <- time(x)
+      ts(y, start=xtime[i[1]], end=xtime[i[l]], frequency = frequency(x))
     }
     else
       y


### PR DESCRIPTION
Not sure if this is typically discouraged, but I modified the `[ ]` extractor to keep the time series properties of a `ts` object when the indices are consecutive.

I often find myself wanting to quickly slice a time series, but find it a bit annoying that the tsp properties are dropped unless I use `window` and actual times for `start` and/or `end`. I tweaked the original method (see `getAnywhere("[.ts")`) to be able to slice a `ts` object with the indices and keep the time series properties if the indices are consecutive. 

I thought you might find it of use, either to export or just to use internally. I can add documentation if you feel it's something you'd like to include in the package.

Some examples:
```
## time series test objects
a <- ts(rnorm(15), start=1, frequency=1)
a <- ts(rnorm(15), start=c(1, 3), frequency=4)
a <- ts(rnorm(15), start=c(2016, 4), frequency=12)
a <- ts(rnorm(15), start=4, frequency=9)

b <- cbind(a, a*2, a*3)

a                  # original ts
a[1]               # keeps tsp
a[1:4]             # keeps tsp
a[c(1, 2, 3, 4)]   # keeps tsp
a[c(1, 2, 3, 5)]   # loses tsp, as before
a[c(1, 2, NA, 4)]  # loses tsp, as before
a[7:13]            # keeps tsp
a[-(7:13)]         # loses tsp, as before
##
b                       # original ts
b[, 1]                  # keeps tsp, as before
b[1:5, 1]               # keeps tsp
b[1:5, 1:2]             # keesp tsp
b[c(1, 2, 3), c(1, 3)]  # keeps tsp
b[7:13, c(1, 3)]        # keeps tsp
b[-(7:13), c(1, 3)]     # loses tsp, as before
b[c(1, 2, 4), 1]        # loses tsp, as before
b[c(1, 2, 4), 1:2]      # loses tsp, as before
b[c(1, 2, 4), c(1, 3)]  # loses tsp, as before
##
b[, c(TRUE, FALSE, TRUE)]               # keeps tsp, as before
b[3:5, c(TRUE, FALSE, TRUE)]            # keeps tsp
b[c(TRUE, TRUE, rep(FALSE, 13)),        # loses tsp, as before
  c(TRUE, FALSE, TRUE)]
b[rep(TRUE, 15), c(TRUE, FALSE, TRUE)]  #loses tsp, as before
```