### PR TITLE
Arima optim.method

### DIFF
--- a/man/arima.Rd
+++ b/man/arima.Rd
@@ -6,7 +6,7 @@ Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
     xreg=NULL, include.mean=TRUE, include.drift=FALSE, 
     include.constant, lambda=model$lambda, transform.pars=TRUE, 
     fixed=NULL, init=NULL, method=c("CSS-ML","ML","CSS"), n.cond,
-    optim.method=("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brend"), 
+    optim.method=("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brent"), 
     optim.control=list(), kappa=1e6, model=NULL)
 }
 

--- a/man/arima.Rd
+++ b/man/arima.Rd
@@ -4,10 +4,8 @@
 \usage{
 Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
     xreg=NULL, include.mean=TRUE, include.drift=FALSE, 
-    include.constant, lambda=model$lambda, transform.pars=TRUE, 
-    fixed=NULL, init=NULL, method=c("CSS-ML","ML","CSS"), n.cond,
-    optim.method=c("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brent"), 
-    optim.control=list(), kappa=1e6, model=NULL)
+    include.constant, lambda=model$lambda, method=c("CSS-ML","ML","CSS"), 
+    model=NULL, ...)
 }
 
 \arguments{
@@ -20,17 +18,10 @@ Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
     The default is FALSE.}
 \item{include.constant}{If TRUE, then \code{include.mean} is set to be TRUE for undifferenced series and \code{include.drift} is set to be TRUE for differenced series. Note that if there is more than one difference taken, no constant is included regardless of the value of this argument. This is deliberate as otherwise quadratic and higher order polynomial trends would be induced.}
 \item{lambda}{Box-Cox transformation parameter. Ignored if NULL. Otherwise, data transformed before model is estimated.}
-\item{transform.pars}{Logical. If true, the AR parameters are transformed to ensure that they remain in the region of stationarity. Not used for method="CSS".}
-\item{fixed}{optional numeric vector of the same length as the total number of parameters. If supplied, only NA entries in fixed will be varied. transform.pars=TRUE will be overridden (with a warning) if any AR parameters are fixed. It may be wise to set transform.pars=FALSE when fixing MA parameters, especially near non-invertibility.}
-\item{init}{optional numeric vector of initial parameter values. Missing values will be filled in, by zeroes except for regression coefficients. Values already specified in fixed will be ignored.}
 \item{method}{Fitting method: maximum likelihood or minimize conditional sum-of-squares. The default (unless there are missing values) is to use conditional-sum-of-squares to find starting values, then maximum likelihood.}
-\item{n.cond}{Only used if fitting by conditional-sum-of-squares: the number of initial observations to ignore. It will be ignored if less than the maximum lag of an AR term.}
-\item{optim.method}{The value passed as the \code{method} argument to 
-\link[stats]{optim}}
-\item{optim.control}{List of control parameters for optim.}
-\item{kappa}{the prior variance (as a multiple of the innovations variance) for the past observations in a differenced model. Do not reduce this.}
 \item{model}{Output from a previous call to \code{Arima}. If model is passed, this same model is fitted to
 \code{x} without re-estimating any parameters.}
+\item{...}{Additional arguments to be passed to \code{\link[stats]{arima}}.}
 }
 
 \description{Largely a wrapper for the \code{\link[stats]{arima}} function in the stats package. The main difference is that this function

--- a/man/arima.Rd
+++ b/man/arima.Rd
@@ -6,7 +6,7 @@ Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
     xreg=NULL, include.mean=TRUE, include.drift=FALSE, 
     include.constant, lambda=model$lambda, transform.pars=TRUE, 
     fixed=NULL, init=NULL, method=c("CSS-ML","ML","CSS"), n.cond,
-    optim.method=("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brent"), 
+    optim.method=c("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brent"), 
     optim.control=list(), kappa=1e6, model=NULL)
 }
 

--- a/man/arima.Rd
+++ b/man/arima.Rd
@@ -5,7 +5,8 @@
 Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
     xreg=NULL, include.mean=TRUE, include.drift=FALSE, 
     include.constant, lambda=model$lambda, transform.pars=TRUE, 
-    fixed=NULL, init=NULL, method=c("CSS-ML","ML","CSS"), n.cond, 
+    fixed=NULL, init=NULL, method=c("CSS-ML","ML","CSS"), n.cond,
+    optim.method=("BFGS", "Nelder-Mead", "CG", "L-BFGS-B", "SANN", "Brend"), 
     optim.control=list(), kappa=1e6, model=NULL)
 }
 
@@ -24,6 +25,8 @@ Arima(x, order=c(0,0,0), seasonal=c(0,0,0),
 \item{init}{optional numeric vector of initial parameter values. Missing values will be filled in, by zeroes except for regression coefficients. Values already specified in fixed will be ignored.}
 \item{method}{Fitting method: maximum likelihood or minimize conditional sum-of-squares. The default (unless there are missing values) is to use conditional-sum-of-squares to find starting values, then maximum likelihood.}
 \item{n.cond}{Only used if fitting by conditional-sum-of-squares: the number of initial observations to ignore. It will be ignored if less than the maximum lag of an AR term.}
+\item{optim.method}{The value passed as the \code{method} argument to 
+\link[stats]{optim}}
 \item{optim.control}{List of control parameters for optim.}
 \item{kappa}{the prior variance (as a multiple of the innovations variance) for the past observations in a differenced model. Do not reduce this.}
 \item{model}{Output from a previous call to \code{Arima}. If model is passed, this same model is fitted to

--- a/man/auto.arima.Rd
+++ b/man/auto.arima.Rd
@@ -11,7 +11,7 @@ auto.arima(x, d=NA, D=NA, max.p=5, max.q=5,
      approximation=(length(x)>100 | frequency(x)>12), xreg=NULL,
      test=c("kpss","adf","pp"), seasonal.test=c("ocsb","ch"),
      allowdrift=TRUE, allowmean=TRUE, lambda=NULL, biasadj=FALSE,
-     parallel=FALSE, num.cores=2)
+     parallel=FALSE, num.cores=2, ...)
 }
 
 \arguments{
@@ -44,6 +44,7 @@ auto.arima(x, d=NA, D=NA, max.p=5, max.q=5,
 \item{biasadj}{Use adjusted back-transformed mean for Box-Cox transformations. If TRUE, point forecasts and fitted values are mean forecast. Otherwise, these points can be considered the median of the forecast densities.}
 \item{parallel}{If \code{TRUE} and \code{stepwise = FALSE}, then the specification search is done in parallel. This can give a significant speedup on mutlicore machines.}
 \item{num.cores}{Allows the user to specify the amount of parallel processes to be used if \code{parallel = TRUE} and \code{stepwise = FALSE}. If \code{NULL}, then the number of logical cores is automatically detected and all available cores are used.}
+\item{...}{Additional arguments to be passed to \code{\link[stats]{arima}}.}
 }
 \description{Returns best ARIMA model according to either AIC, AICc or BIC value.
 The function conducts a search over


### PR DESCRIPTION
I've added an argument to the Arima function to allow the user to select the optimization algorithm used in the call to stats::arima. The current implementation uses the default BFGS algorithm as set by stats::arima, and when BFGS wasn't converging, I added this functionality.

P.S. Thanks for this very well written forecast package. I'm typically a Python user, but your auto.arima implementation all but forced me to switch for the work I'm doing with time series modelling.