### PR TITLE
Keep tsp properties when subsetting

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -48,7 +48,7 @@ subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL, ...
   else
     if(min(season) < 1L | max(season) > frequency(x))
       stop(paste("Seasons must be between 1 and", frequency(x)))
-  
+
   start <- utils::head(time(x)[is.element(cycle(x), season)],1)
   if("mts" %in% class(x)){
     x <- subset.matrix(x, is.element(cycle(x), season))
@@ -57,4 +57,47 @@ subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL, ...
     x <- subset.default(x, is.element(cycle(x), season))
   }
     return(ts(x, frequency=length(season), start=start))
+}
+
+
+### Method to keep ts properties while subsetting
+"[.ts" <- function (x, i, j, drop = TRUE, tsp.keep)
+{
+  ## Original method when tsp.keep missing
+  if (missing(tsp.keep)){
+    y <- NextMethod("[")
+    if (missing(i))
+      y <- ts(y, start = start(x), frequency = frequency(x))
+  ## If tsp.keep given
+  }else {
+    ## Make sure call order is correct with appropriate missing i or j
+    fcall <- match.call()
+    fcall$tsp.keep <- NULL
+    if ((NCOL(x) > 1) && missing(j)){
+      fcall$drop <- NULL
+      fcall$j <- quote(expr=)
+      fcall$drop <- drop
+    }
+    if ((NCOL(x) > 1) && missing(i)){
+      fcall$drop <- NULL
+      fcall$j <- NULL
+      fcall$i <- quote(expr=)
+      fcall$j <- j
+      fcall$drop <- drop
+    }
+    ## Keep tsp attributes if tsp.keep=TRUE
+    if (isTRUE(tsp.keep)){
+      y <- eval(fcall)
+      if (!missing(i)){
+        xtime <- time(x)
+        l <- length(i)
+        y <- ts(y, start=xtime[i[1]], end=xtime[i[l]], frequency = frequency(x))
+      }
+    ## Force drop of tsp attributes if tsp.keep!=TRUE
+    } else{
+      y <- eval(fcall)
+      tsp(y) <- NULL
+    }
+  }
+  return(y)
 }


### PR DESCRIPTION
Sorry for the feeling of deja vu, but I went back to thinking about #283 and whether there's a convenient, yet safe, way to implement something like it. I think this solution might be pretty reasonable so I thought I'd pass it along to get your thoughts. 

I added a `tsp.keep` argument to the `[.ts` method. If this argument is missing, everything defaults to the original behavior so nothing unexpected should happen nor should it break any existing code.

Now, if one does pass `tsp.keep` with a value of `TRUE`, the `tsp` attributes are maintained. If passed as `FALSE` (or actually, any non-true), the `tsp` attributes are dropped (this includes the scenario where the original method kept the `tsp` attributes, namely when selecting full columns from a multivariate object). 

I think having this extra argument makes it convenient enough to use, yet innocuous enough to not get in the way or break existing code. 

Here's some sample code to copy & paste to get a quick feel for it:
```
a <- lynx
##
a[1]
a[1, tsp=TRUE]
a[6]
a[6, tsp=TRUE]
a[6, tsp=FALSE]
a[1:4]
a[1:4, tsp=TRUE]
a[1:4, tsp=FALSE]
a[1:4, tsp=1234]  #Any non-true drops tsp()

b <- cbind(lynx, lynx)
##
b[1:5, ]
b[1:5, tsp=TRUE]
b[1:5, tsp=FALSE]
b[, 1]
b[, 1, tsp=TRUE]
b[, 1, tsp=FALSE]
b[1:5, 2]
b[1:5, 2, tsp=TRUE]
b[1:5, 2, tsp=FALSE]
b[,1:2]
b[,1:2, tsp=TRUE]
b[,1:2, tsp=FALSE]

## Doesn't work with non-sequential indices
## Can either add check/warning, or just note in documentation
a[c(1, 2, 6, 9)]
a[c(1, 2, 6, 9), tsp=TRUE]
a[c(1, 2, 6, 9), tsp=FALSE] #This is fine though!
```