### PR TITLE
Added support for continuous colouring in ggseasonplot()

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -791,7 +791,7 @@ ggmonthplot <- function (x, labels = NULL, times = time(x), phase = cycle(x), ..
   }
 }
 
-ggseasonplot <- function (x, year.labels=FALSE, year.labels.left=FALSE, type=NULL, col=NULL, labelgap=0.04, ...){
+ggseasonplot <- function (x, year.labels=FALSE, year.labels.left=FALSE, type=NULL, col=NULL, continuous=FALSE, labelgap=0.04, ...){
   if (requireNamespace("ggplot2")){
     if (!inherits(x, "ts")){
       stop("autoplot.seasonplot requires a ts object, use x=object")
@@ -805,8 +805,13 @@ ggseasonplot <- function (x, year.labels=FALSE, year.labels.left=FALSE, type=NUL
     if(s <= 1)
       stop("Data are not seasonal")
 
-    data <- data.frame(y=as.numeric(x),year=factor(trunc(time(x))),time=as.numeric(round(time(x)%%1,digits = 6)))
-
+    data <- data.frame(y=as.numeric(x),year=trunc(time(x)),time=as.numeric(round(time(x)%%1,digits = 6)))
+    data$year <- if(continuous){
+      as.numeric(data$year)
+    }
+    else{
+      as.factor(data$year)
+    }
     #Initialise ggplot object
     p <- ggplot2::ggplot(ggplot2::aes_(x=~time, y=~y, group=~year, colour=~year), data=data, na.rm=TRUE)
     #p <- p + ggplot2::scale_x_continuous()
@@ -815,12 +820,17 @@ ggseasonplot <- function (x, year.labels=FALSE, year.labels.left=FALSE, type=NUL
     p <- p + ggplot2::geom_line()
 
     if(!is.null(col)){
-      ncol <- length(unique(data$year))
-      if(length(col)==1){
-        p <- p + ggplot2::scale_color_manual(guide="none", values=rep(col, ncol))
+      if(continuous){
+        p <- p + ggplot2::scale_color_gradientn(colours=col)
       }
-      else{
-        p <- p + ggplot2::scale_color_manual(values=rep(col, ceiling(ncol/length(col)))[1:ncol])
+      else{      
+        ncol <- length(unique(data$year))
+        if(length(col)==1){
+          p <- p + ggplot2::scale_color_manual(guide="none", values=rep(col, ncol))
+        }
+        else{
+          p <- p + ggplot2::scale_color_manual(values=rep(col, ceiling(ncol/length(col)))[1:ncol])
+        }
       }
     }
 

--- a/man/seasonplot.Rd
+++ b/man/seasonplot.Rd
@@ -7,7 +7,7 @@
     col=1, labelgap=0.1, ...)
 
 ggseasonplot(x, year.labels=FALSE, year.labels.left=FALSE, 
-    type=NULL, col=NULL, labelgap=0.04,
+    type=NULL, col=NULL, continuous=FALSE, labelgap=0.04,
     ...)
 }
 \arguments{
@@ -21,6 +21,7 @@ ggseasonplot(x, year.labels=FALSE, year.labels.left=FALSE,
 \item{xlab}{X-axis label.}
 \item{ylab}{Y-axis label.}
 \item{col}{Colour}
+\item{continuous}{Should the colour scheme for years be continuous or discrete?}
 \item{labelgap}{Distance between year labels and plotted lines}
 \item{\dots}{additional arguments to \code{\link[graphics]{plot}}.} }
 \description{Plots a seasonal plot as described in Hyndman and Athanasopoulos (2014, chapter 2).
@@ -33,7 +34,8 @@ ggseasonplot(x, year.labels=FALSE, year.labels.left=FALSE,
 
 \author{Rob J Hyndman & Mitchell O'Hara-Wild}
 \seealso{\code{\link[stats]{monthplot}}}
-\examples{seasonplot(AirPassengers,col=rainbow(12),year.labels=TRUE)
-ggseasonplot(AirPassengers,col=rainbow(12),year.labels=TRUE)
+\examples{seasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
+ggseasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
+ggseasonplot(AirPassengers, year.labels=TRUE, continuous=TRUE)
 }
 \keyword{ts}


### PR DESCRIPTION
Issue #310 

Using the continuous=TRUE parameter (default FALSE)

Works with numerical colours and hex.

seasonplot(AirPassengers, col=1:2)
![rplot18](https://cloud.githubusercontent.com/assets/16127127/15237106/7876b40c-190e-11e6-8410-fdd00cc6ead9.png)

ggseasonplot(AirPassengers, col=1:2)
![rplot17](https://cloud.githubusercontent.com/assets/16127127/15237095/53aca172-190e-11e6-8bc5-36da457f0eea.png)

ggseasonplot(AirPassengers, col=1:2, continuous = TRUE)
ggseasonplot(AirPassengers, col=c("#000000","#FF0000"), continuous = TRUE)
![rplot16](https://cloud.githubusercontent.com/assets/16127127/15237099/5dfe02f6-190e-11e6-8148-5a8f28e146f3.png)
