### PR TITLE
Added a continuous parameter to allow for discrete lag colours

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -628,13 +628,14 @@ ggtsdisplay <- function(x, plot.type=c("partial","scatter","spectrum"),
   }
 }
 
-gglagplot <- function(x, lags = 1, set.lags = 1:lags, diag=TRUE, diag.col="gray", do.lines = TRUE, colour = TRUE, labels = FALSE, seasonal = TRUE, ...){
+gglagplot <- function(x, lags = 1, set.lags = 1:lags, diag=TRUE, diag.col="gray", do.lines = TRUE, colour = TRUE, continuous = TRUE, labels = FALSE, seasonal = TRUE, ...){
   if (requireNamespace("ggplot2")){
     if(frequency(x)>1){
       linecol = cycle(x)
     }
     else{
       seasonal=FALSE
+      continuous=TRUE
     }
     x <- as.matrix(x)
     
@@ -649,6 +650,9 @@ gglagplot <- function(x, lags = 1, set.lags = 1:lags, diag=TRUE, diag.col="gray"
         }
         data <- rbind(data, data.frame(lagnum = 1:(n-lag), freqcur = ifelse(rep(seasonal,n-lag),linecol[(lag+1):n],(lag+1):n), orig = x[(lag+1):n,i], lagged = x[1:(n-lag),i], lag = rep(lag, n-lag), series = rep(sname, n-lag)))
       }
+    }
+    if(!continuous){
+      data$freqcur <- factor(data$freqcur)
     }
     
     #Initialise ggplot object
@@ -695,7 +699,12 @@ gglagplot <- function(x, lags = 1, set.lags = 1:lags, diag=TRUE, diag.col="gray"
     }
     p <- p + ggplot2::theme(aspect.ratio=1)
     if(colour){
-      p <- p + ggplot2::guides(colour = ggplot2::guide_colourbar(title=ifelse(seasonal, "season", "time")))
+      if(continuous){
+        p <- p + ggplot2::guides(colour = ggplot2::guide_colourbar(title=ifelse(seasonal, "season", "time")))
+      }
+      else{
+        p <- p + ggplot2::guides(colour = ggplot2::guide_legend(title=ifelse(seasonal, "season", "time")))
+      }
     }
     
     p <- p + ggAddExtras(ylab = NULL, xlab = NULL)

--- a/man/gglagplot.Rd
+++ b/man/gglagplot.Rd
@@ -3,7 +3,7 @@
 \alias{gglagchull}
 \title{Time series lag ggplots}
 \usage{gglagplot(x, lags = 1, set.lags = 1:lags, diag=TRUE,
-  diag.col="gray", do.lines = TRUE, colour = TRUE,
+  diag.col="gray", do.lines = TRUE, colour = TRUE, continuous = FALSE,
   labels = FALSE, seasonal = TRUE, ...)
 gglagchull(x, lags = 1, set.lags = 1:lags, diag=TRUE, 
   diag.col="gray", ...)
@@ -16,6 +16,7 @@ gglagchull(x, lags = 1, set.lags = 1:lags, diag=TRUE,
 \item{diag.col}{color to be used for the diagonal if(diag).}
 \item{do.lines}{if TRUE, lines will be drawn, otherwise points will be drawn.}
 \item{colour}{logical indicating if lines should be coloured.}
+\item{continuous}{Should the colour scheme for years be continuous or discrete?}
 \item{labels}{logical indicating if labels should be used.}
 \item{seasonal}{Should the line colour be based on seasonal characteristics (TRUE), or sequential (FALSE).}
 \item{\dots}{Not used (for consistency with lag.plot)}


### PR DESCRIPTION
Maybe this should be restricted to be only when seasonal=TRUE

#320

gglagplot(ausbeer, do.lines=FALSE, labels = FALSE, lags=9, continuous = FALSE)
![rplot19](https://cloud.githubusercontent.com/assets/16127127/15241938/6c660c12-1936-11e6-9d99-78d3778c7158.png)
