### PR TITLE
Made tslm() have identical object structure as lm()

### DIFF
--- a/R/lm.R
+++ b/R/lm.R
@@ -103,8 +103,8 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...){
   fit$residuals <- ts(residuals(fit))
   fit$fitted.values <- ts(fitted(fit))
   tsp(fit$residuals) <- tsp(fit$fitted.values) <- tsp(data[,1]) <- tspx
-  fit$data <- data # This unfortunately needs to be a mf, to be able to separate multivariate response
-  fit$x <- data[,1] ## Do we want to include subsetting here?
+  #fit$data <- data # This unfortunately needs to be a mf, to be able to separate multivariate response
+  #fit$x <- data[,1] ## Do we want to include subsetting here?
   fit$call <- cl
   if(NCOL(data[,1])>1){ #Univariate response
     fit$data <- data[,1]


### PR DESCRIPTION
Removed fit$x and fit$data, resolves dwtest() issue #329.

```R
library(fpp)
fit1 <- tslm(sales ~ advert, data=advert)
fit2 <- lm(sales ~ advert, data=advert)

dwtest(fit1)
dwtest(fit2)

fc1 <- forecast(fit1, newdata=data.frame(advert=1:7))
fc2 <- forecast(fit2, newdata=data.frame(advert=1:7))

plot(fc1)
autoplot(fc1)

plot(fc2)
autoplot(fc2)
```