### PR TITLE
handle internal NA values at lags with 0 coefficients when simulating

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -134,7 +134,7 @@ myarima.sim <- function (model, n, x, e, ...)
     {
       lagged.x.values <- x.with.data[(i-len.ar):(i-1)]
       ar.coefficients <- model$ar[length(model$ar):1]
-      sum.mutliplied.x <- sum(lagged.x.values * (ar.coefficients))
+      sum.mutliplied.x <- sum((lagged.x.values * ar.coefficients)[ar.coefficients != 0])
       x.with.data[i] <- x.with.data[i]+sum.mutliplied.x
     }
 


### PR DESCRIPTION
The vector lagged.x.values may contain NA values that are not relevant if the corresponding ar.coefficients are 0.  Previously, sum(lagged.x.values * (ar.coefficients)) resulted in an unnecessary NA in that case.  We can avoid this by subsetting to indices with non-zero ar.coefficients before summing.  This came up in simulating with a seasonal ARIMA model where the "low season" was occasionally unobserved, but those values are not relevant for the simulation task.