### PR TITLE
Fix bug in myarima.sim introduced in commit 1eb839c.

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -134,7 +134,7 @@ myarima.sim <- function (model, n, x, e, ...)
     {
       lagged.x.values <- x.with.data[(i-len.ar):(i-1)]
       ar.coefficients <- model$ar[length(model$ar):1]
-      sum.multiplied.x <- sum((lagged.x.values * ar.coefficients)[abs(ar.coefficients) < 1e-13])
+      sum.multiplied.x <- sum((lagged.x.values * ar.coefficients)[abs(ar.coefficients) > .Machine$double.eps])
       x.with.data[i] <- x.with.data[i]+sum.multiplied.x
     }
 


### PR DESCRIPTION
We want to keep the coefficients that are different from 0 when doing this summation; code in commit 1eb839c kept coefficients with small absolute value instead of large.