### PR TITLE
Revert simulate.nnetar bootstrap innov

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -193,7 +193,7 @@ myarima.sim <- function (model, n, x, e, ...)
     delta.four <- diff(data, lag=m, differences=D)
     regular.xi <- delta.four[(length(delta.four)-D):length(delta.four)]
     x <- diffinv(x, differences = d, xi=regular.xi[length(regular.xi)-(d:1)+1])[-(1:d)]
- 
+
     #Then seasonal
     i <- length(data) - D*m + 1
     seasonal.xi <- data[i:length(data)]
@@ -484,17 +484,20 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
   ## set simulation innovations
   if(bootstrap)
   {
-    res <- na.omit(residuals(object))/object$scalex$scale
+    res <- na.omit(rowMeans(sapply(object$model, residuals)))
+    ## res <- na.omit(residuals(object, type=innovation))/object$scalex$scale
     e <- sample(res,nsim,replace=TRUE)
   }
   else if(is.null(innov))
   {
-    res <- na.omit(residuals(object))/object$scalex$scale
+    res <- na.omit(rowMeans(sapply(object$model, residuals)))
+    ## res <- na.omit(residuals(object, type=innovation))/object$scalex$scale
     e <- rnorm(nsim, 0, sd(res, na.rm=TRUE))
   }
   else if(length(innov)==nsim)
     e <- innov/object$scalex$scale
   else if(length(innov)==1)
+    ## to pass innov=0 so simulation equals mean forecast
     e <- rep(innov, nsim)/object$scalex$scale
   else
     stop("Length of innov must be equal to nsim")


### PR DESCRIPTION
Apologies I hadn't fixed #369 yet. One quick fix to 660f1512e13e117c581716d470b448af17bdfe43 though, the bootstrapped and normal innovations were correct before. 

- The line  ` rowMeans(sapply(object$model, residuals)) `   grabbed the raw residuals from inside the `nnet` objects and thus automatically accounted for both the scaling and any Box-Cox transformations.

- I left the other lines just commented out for now, so once #368 is implemented it can simply be reverted to that (both would produce the same result, but using `residuals` might be clearer code).

- I also added a comment to clarify my intent with
```
else if(length(innov)==1)
  e <- rep(innov, nsim)
```
which was simply to have `simulate.nnetar` give results consistent with the mean forecast if `innov=0` (i.e. automatically make it the correct length). Not sure if you care to keep this or would rather remove it.