### PR TITLE
stlm() now backtransforms fitted values

### DIFF
--- a/R/season.R
+++ b/R/season.R
@@ -219,6 +219,10 @@ stlm <- function(y ,s.window=7, robust=FALSE, method=c("ets","arima"),
   # Fitted values and residuals
   fits <- fitted(fit) + stld$time.series[,"seasonal"]
   res <- residuals(fit)
+  if(!is.null(lambda)){
+    fits <- InvBoxCox(fits, lambda, biasadj, var(res))
+    attr(lambda, "biasadj") <- biasadj
+  }
 
   return(structure(list(stl=stld,model=fit, lambda=lambda, x=origx, m=frequency(origx),
      fitted=fits, residuals=res),class="stlm"))

--- a/man/forecast.stl.Rd
+++ b/man/forecast.stl.Rd
@@ -6,7 +6,7 @@
 \title{Forecasting using stl objects}
 \usage{
 stlm(y, s.window=7, robust=FALSE, method=c("ets","arima"), 
-     modelfunction=NULL, etsmodel="ZZN", lambda=NULL, xreg=NULL, 
+     modelfunction=NULL, etsmodel="ZZN", lambda=NULL, biasadj=FALSE, xreg=NULL, 
      allow.multiplicative.trend=FALSE, x=y, ...)
 stlf(y, h=frequency(x)*2, s.window=7, t.window=NULL, robust=FALSE,
     lambda=NULL, biasadj=FALSE, x=y, ...)


### PR DESCRIPTION
Presumably all fitted values should be backtransformed? Or none of them? Which is preferred?