### PR TITLE
Added generic support for refitting custom modelfunction

### DIFF
--- a/R/season.R
+++ b/R/season.R
@@ -199,7 +199,7 @@ stlm <- function(y ,s.window=7, robust=FALSE, method=c("ets","arima"), modelfunc
         modelfunction <- function(x,...){return(model$modelfunction(x,model=model$model, ...))}
       }
     }
-    if(is.null(modelfunction){
+    if(is.null(modelfunction)){
       stop("Unknown model type")
     }
   }

--- a/R/season.R
+++ b/R/season.R
@@ -194,7 +194,12 @@ stlm <- function(y ,s.window=7, robust=FALSE, method=c("ets","arima"), modelfunc
     else if(inherits(model$model, "Arima")){
       modelfunction <- function(x,...){return(Arima(x,model=model$model, ...))}
     }
-    else{
+    else if(!is.null(model$modelfunction)){
+      if("method"%in%names(formals(model$modelfunction))){
+        modelfunction <- function(x,...){return(model$modelfunction(x,model=model$model, ...))}
+      }
+    }
+    if(is.null(modelfunction){
       stop("Unknown model type")
     }
   }
@@ -233,8 +238,8 @@ stlm <- function(y ,s.window=7, robust=FALSE, method=c("ets","arima"), modelfunc
     attr(lambda, "biasadj") <- biasadj
   }
 
-  return(structure(list(stl=stld,model=fit, lambda=lambda, x=origx, m=frequency(origx),
-     fitted=fits, residuals=res),class="stlm"))
+  return(structure(list(stl=stld, model=fit, modelfunction=modelfunction, lambda=lambda,
+                        x=origx, m=frequency(origx), fitted=fits, residuals=res),class="stlm"))
 }
 
 forecast.stlm <- function(object, h = 2*object$m, level = c(80, 95), fan = FALSE,

--- a/R/season.R
+++ b/R/season.R
@@ -195,7 +195,7 @@ stlm <- function(y ,s.window=7, robust=FALSE, method=c("ets","arima"), modelfunc
       modelfunction <- function(x,...){return(Arima(x,model=model$model, ...))}
     }
     else if(!is.null(model$modelfunction)){
-      if("method"%in%names(formals(model$modelfunction))){
+      if("model"%in%names(formals(model$modelfunction))){
         modelfunction <- function(x,...){return(model$modelfunction(x,model=model$model, ...))}
       }
     }


### PR DESCRIPTION
```R
b <- stlm(USAccDeaths, modelfunction = Arima)
c <- stlm(USAccDeaths, model=b)
```

Runs only when `model$modelfunction` accepts the `model` argument.

Enhancement #303