### PR TITLE
Enhanced geom_forecast(series=*) functionality

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1256,14 +1256,11 @@ geom_forecast <- function(mapping = NULL, data = NULL, stat = "forecast",
     data <- fortify(mapping, PI=plot.conf)
     mapping <- ggplot2::aes_(x = ~x, y = ~y)
     if(plot.conf){
-      mapping$level <- quote(level)
       mapping$group <- quote(-level)
-      mapping$ymin <- quote(ymin)
-      mapping$ymax <- quote(ymax)
     }
     if(!missing(series)){
-      mapping$colour <- quote(series)
       data <- transform(data, series=series)
+      mapping$colour <- quote(series)
     }
   }
   else if(is.mforecast(mapping)){


### PR DESCRIPTION
Now always sets colour according to series, not only when series colour is inherited from ggplot() mapping. (Usually from autoplot.mts)

```R
autoplot(USAccDeaths) + 
    geom_forecast(snaive(USAccDeaths), series="Seasonal Naive", plot.conf = FALSE) + 
    geom_forecast(naive(USAccDeaths, h=24), series="Naive", plot.conf = FALSE) +
    geom_forecast(forecast(ets(USAccDeaths)), series="ETS", plot.conf = FALSE) + 
    guides(colour=guide_legend(title="Forecast"))
```