### PR TITLE
geom_forecast() overhaul

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1191,17 +1191,48 @@ GeomForecast <- ggplot2::ggproto("GeomForecast", ggplot2::Geom, ## Produces both
     linetype = 1, weight = 1, alpha = 1),
   draw_key = function(data, params, size){
     lwd <- min(data$size, min(size) / 4)
-
-    grid::rectGrob(
-      width = unit(1, "npc") - unit(lwd, "mm"),
-      height = unit(1, "npc") - unit(lwd, "mm"),
-      gp = grid::gpar(
-        col = data$colour,
-        fill = alpha(data$colour, data$alpha),
-        lty = data$linetype,
-        lwd = lwd * .pt,
-        linejoin = "mitre"
-      ))
+    
+    col <- data$colour
+    altcol <- col2rgb(col)
+    altcol <- rgb2hsv(altcol[[1]],altcol[[2]],altcol[[3]])
+    
+    # Calculate and set colour
+    linecol <- colorspace::hex(colorspace::HSV(altcol[1]*360, 1, 2/3))
+    altcol1 <- colorspace::hex(colorspace::HSV(altcol[1]*360, 7/12, 5/6))
+    altcol2 <- colorspace::hex(colorspace::HSV(altcol[1]*360, 1/6, 1))
+    print(data)
+    grid::grobTree(
+      grid::rectGrob(
+        width = unit(1, "npc") - unit(lwd, "mm"),
+        height = unit(1, "npc") - unit(lwd, "mm"),
+        gp = grid::gpar(
+          col = altcol2,
+          fill = alpha(altcol2, data$alpha),
+          lty = data$linetype,
+          lwd = lwd * .pt,
+          linejoin = "mitre")
+      ),
+      grid::polygonGrob(
+        x=c(0,  0.4,0.6,0.8,1,1,  0.6,0.4,0.1,0),
+        y=c(0.5,0.9,0.7,1,  1,0.6,0.1,0.3,0  ,0),
+        gp = grid::gpar(
+          col = altcol1,
+          fill = alpha(altcol1, data$alpha),
+          lty = data$linetype,
+          lwd = lwd * .pt,
+          linejoin = "mitre")
+      ),
+      grid::linesGrob(
+        x=c(0, 0.4, 0.6, 1),
+        y=c(0.2, 0.6, 0.4, 0.9),
+        gp = grid::gpar(
+          col = linecol,
+          fill = alpha(linecol, data$alpha),
+          lty = data$linetype,
+          lwd = lwd * .pt,
+          linejoin = "mitre")
+      )
+    )
   },
   handle_na = function(self, data, params){ #Consider removing/changing
     data

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1269,16 +1269,17 @@ GeomForecastPoint <- ggplot2::ggproto("GeomForecastPoint", GeomForecast, ## Prod
       GeomBlank$draw_panel
     }
     else if(NROW(data)==1){ #Point
-      GeomForecastIntervalGeom <- GeomLinerange$draw_panel
+      GeomForecastPointGeom <- GeomPoint$draw_panel
       pointpred <- transform(data, fill = NA, colour = linecol, size=1, shape=19, stroke=0.5)
     }
     else{ #Line
-      GeomForecastIntervalGeom <- GeomRibbon$draw_group
+      GeomForecastPointGeom <- GeomLine$draw_panel
       pointpred <- transform(data, fill = NA, colour = linecol)
     }
+    
     #Draw forecast points
     ggplot2:::ggname("geom_forecast_point",
-                     grid::grobTree(GeomPoint$draw_panel(pointpred, panel_scales, coord)))
+                     grid::grobTree(GeomForecastPointGeom(pointpred, panel_scales, coord)))
   }
 )
 

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1355,8 +1355,6 @@ geom_forecast <- function(mapping = NULL, data = NULL, stat = "forecast",
     }
   }
   else if(is.mforecast(mapping)){
-    #Convert mforecast to list of forecast
-    #return lapply of geom_forecast with params on list
     cl <- match.call()
     #cl[[1]] <- quote(list)
     cl$mapping <- quote(fclist[[i]])

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1200,7 +1200,6 @@ GeomForecast <- ggplot2::ggproto("GeomForecast", ggplot2::Geom, ## Produces both
     linecol <- colorspace::hex(colorspace::HSV(altcol[1]*360, 1, 2/3))
     altcol1 <- colorspace::hex(colorspace::HSV(altcol[1]*360, 7/12, 5/6))
     altcol2 <- colorspace::hex(colorspace::HSV(altcol[1]*360, 1/6, 1))
-    print(data)
     grid::grobTree(
       grid::rectGrob(
         width = unit(1, "npc") - unit(lwd, "mm"),
@@ -1212,16 +1211,16 @@ GeomForecast <- ggplot2::ggproto("GeomForecast", ggplot2::Geom, ## Produces both
           lwd = lwd * .pt,
           linejoin = "mitre")
       ),
-      grid::polygonGrob(
-        x=c(0,  0.4,0.6,0.8,1,1,  0.6,0.4,0.1,0),
-        y=c(0.5,0.9,0.7,1,  1,0.6,0.1,0.3,0  ,0),
-        gp = grid::gpar(
-          col = altcol1,
-          fill = alpha(altcol1, data$alpha),
-          lty = data$linetype,
-          lwd = lwd * .pt,
-          linejoin = "mitre")
-      ),
+      # grid::polygonGrob(
+      #   x=c(0,  0.4,0.6,0.8,1,1,  0.6,0.4,0.1,0),
+      #   y=c(0.5,0.9,0.7,1,  1,0.6,0.1,0.3,0  ,0),
+      #   gp = grid::gpar(
+      #     col = altcol1,
+      #     fill = alpha(altcol1, data$alpha),
+      #     lty = data$linetype,
+      #     lwd = lwd * .pt,
+      #     linejoin = "mitre")
+      # ),
       grid::linesGrob(
         x=c(0, 0.4, 0.6, 1),
         y=c(0.2, 0.6, 0.4, 0.9),

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1312,7 +1312,10 @@ geom_forecast <- function(mapping = NULL, data = NULL, stat = "forecast",
     mapping <- ggplot2::aes_(y=~y, x=~x)
   }
   if(stat=="forecast"){
-    paramlist <- list(na.rm = na.rm, plot.conf=plot.conf, series=series, ...)
+    if(!is.null(series)){
+      warning("To use the series argument, provide geom_forecast() with a forecast object.")
+    }
+    paramlist <- list(na.rm = na.rm, plot.conf=plot.conf, ...)
   }
   else{
     paramlist <- list(na.rm = na.rm, ...)

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1357,7 +1357,23 @@ geom_forecast <- function(mapping = NULL, data = NULL, stat = "forecast",
   else if(is.mforecast(mapping)){
     #Convert mforecast to list of forecast
     #return lapply of geom_forecast with params on list
-    stop("mforecast objects not yet supported. Try calling geom_forecast() for several forecast objects")
+    cl <- match.call()
+    #cl[[1]] <- quote(list)
+    cl$mapping <- quote(fclist[[i]])
+    if(!is.null(series)){
+      #cl$series <- quote(series)
+      if(length(series)!=length(mapping$mean)){
+        series <- names(mapping$mean)
+      }
+    }
+    #return(lapply(mforecastsplit(mapping), function(x)do.call(geom_forecast, eval(cl))))
+    fclist <- mforecastsplit(mapping)
+    out <- list()
+    for(i in 1:length(fclist)){
+      cl$series <- series[i]
+      out[[i]] <- eval(cl)
+    }
+    return(out)
   }
   else if(is.ts(mapping)){
     data <- data.frame(y = as.numeric(mapping), x = as.numeric(time(mapping)))

--- a/R/mforecast.R
+++ b/R/mforecast.R
@@ -28,6 +28,27 @@ mlmsplit <- function(x, index=NULL){
   return(x)
 }
 
+mforecastsplit <- function(x, index=1:length(x$mean)){
+  out <- list()
+  for(i in index){
+    out[[i]] <- structure(list(level = x$level,
+                     x = x$x[,i], 
+                     model = x$model[[i]],
+                     mean = x$mean[[i]],
+                     lower = x$lower[[i]],
+                     upper = x$upper[[i]],
+                     method = x$method[i],
+                     residuals = x$residuals[,i],
+                     fitted = x$fitted[,i],
+                     series = names(x$mean)[i]),
+                     class = "forecast")
+  }
+  if(length(index)==1){
+    out <- out[[1]]
+  }
+  return(out)
+}
+
 forecast.mlm <- function(object, newdata, h=10, level=c(80,95), fan=FALSE, lambda=object$lambda, biasadj=NULL, ts=TRUE, ...)
 {
   K <- NCOL(object$coefficients)

--- a/man/geom_forecast.Rd
+++ b/man/geom_forecast.Rd
@@ -44,7 +44,6 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link{borders}}.}
 \item{plot.conf}{If \code{FALSE}, confidence intervals will not be plotted, giving only the forecast line.}
-\item{h}{Number of periods for forecasting}
 \item{series}{Matches an unidentified forecast layer with a coloured object on the plot.}
 \item{...}{Additional arguments for \code{\link{forecast.ts}}, other arguments are passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like

--- a/man/geom_forecast.Rd
+++ b/man/geom_forecast.Rd
@@ -5,9 +5,7 @@
 \title{Forecast plot}
 \usage{geom_forecast(mapping = NULL, data = NULL, stat = "forecast",
     position = "identity", na.rm = FALSE, show.legend = NA,
-    inherit.aes = TRUE, plot.conf=TRUE, h=NULL, level=c(80,95), fan=FALSE,
-    robust=FALSE, lambda=NULL, find.frequency=FALSE,
-    allow.multiplicative.trend=FALSE, series, ...)
+    inherit.aes = TRUE, plot.conf=TRUE, series=NULL, ...)
 }
 
 \arguments{
@@ -45,19 +43,10 @@ a warning.  If \code{TRUE} silently removes missing values.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link{borders}}.}
-
 \item{plot.conf}{If \code{FALSE}, confidence intervals will not be plotted, giving only the forecast line.}
 \item{h}{Number of periods for forecasting}
-\item{level}{Confidence level for prediction intervals.}
-\item{fan}{If TRUE, \code{level} is set to \code{seq(51,99,by=3)}. This is suitable for fan plots.}
-\item{robust}{If TRUE, the function is robust to missing values and outliers in \code{object}. This argument is only valid when \code{object} is of class \code{ts}.}
-\item{lambda}{Box-Cox transformation parameter.}
-\item{find.frequency}{If TRUE, the function determines the appropriate period, if the data is of unknown period.}
-\item{allow.multiplicative.trend}{If TRUE, then ETS models with multiplicative trends are allowed. Otherwise, only additive or no trend ETS models are permitted.}
-
 \item{series}{Matches an unidentified forecast layer with a coloured object on the plot.}
-
-\item{...}{other arguments passed on to \code{\link{layer}}. These are
+\item{...}{Additional arguments for \code{\link{forecast.ts}}, other arguments are passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{color = "red"} or \code{alpha = .5}. They may also be parameters
 to the paired geom/stat.}


### PR DESCRIPTION
- mforecast support
- rewritten Geom structure
- Added support for forecasts of length 1 (and 0)
- Custom geom_forecast() draw_key
- Far more structurally robust
- Clearer code
- Removed aesthetic warnings

Code sample:
```
ldeaths <- cbind(mdeaths, fdeaths)
autoplot(USAccDeaths) + geom_forecast()
autoplot(ldeaths) + geom_forecast()

fit <- tslm(ldeaths ~ trend + season)
mfcast <- forecast(fit, h=24)
ggplot() + geom_forecast(mfcast)
ggplot() + geom_forecast(mfcast, series = TRUE) # Anything without a name for each series will find the series name
ggplot() + geom_forecast(mfcast, series = c("Male deaths", "Female deaths")) # But it can be set manually if it doesn't work

# When the forecast length is one, the graph will now work (using point and linerange, not line and ribbon)
autoplot(ldeaths) + geom_forecast(h=1)
```