### PR TITLE
nnetar residuals

### DIFF
--- a/R/residuals.R
+++ b/R/residuals.R
@@ -1,11 +1,11 @@
-residuals.ar <- function(object, type=c("innovation","response"),...) 
+residuals.ar <- function(object, type=c("innovation","response"),...)
 {
   type <- match.arg(type)
   # innovation and response residuals are the same for AR models
   object$resid
 }
 
-residuals.Arima <- function(object, type=c("innovation","response","regression"), h=1, ...) 
+residuals.Arima <- function(object, type=c("innovation","response","regression"), h=1, ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -33,7 +33,7 @@ residuals.Arima <- function(object, type=c("innovation","response","regression")
   }
 }
 
-residuals.bats <- function(object, type=c("innovation","response"), h=1, ...) 
+residuals.bats <- function(object, type=c("innovation","response"), h=1, ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -42,7 +42,7 @@ residuals.bats <- function(object, type=c("innovation","response"), h=1, ...)
     getResponse(object) - fitted(object, h=h)
 }
 
-residuals.ets <- function(object, type=c("innovation","response"), h=1, ...) 
+residuals.ets <- function(object, type=c("innovation","response"), h=1, ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -51,7 +51,7 @@ residuals.ets <- function(object, type=c("innovation","response"), h=1, ...)
     getResponse(object) - fitted(object, h=h)
 }
 
-residuals.forecast <- function(object, type=c("innovation","response"), ...) 
+residuals.forecast <- function(object, type=c("innovation","response"), ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -60,7 +60,7 @@ residuals.forecast <- function(object, type=c("innovation","response"), ...)
     getResponse(object) - fitted(object)
 }
 
-residuals.fracdiff <- function(object, type=c("innovation","response"), ...) 
+residuals.fracdiff <- function(object, type=c("innovation","response"), ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -92,16 +92,19 @@ residuals.geom_forecast <- function(object, type=c("innovation","response"), ...
     getResponse(object) - fitted(object)
 }
 
-residuals.nnetar <- function(object, type=c("innovation","response"), h=1, ...) 
+residuals.nnetar <- function(object, type=c("innovation","response"), h=1, ...)
 {
   type <- match.arg(type)
-  if(type=="innovation")
-    object$residuals
+  if(type=="innovation" & !is.null(object$lambda))
+    if(!is.null(object$scalex$scale))
+      na.omit(rowMeans(sapply(object$model, residuals)))/object$scalex$scale
+    else
+      na.omit(rowMeans(sapply(object$model, residuals)))
   else
     getResponse(object) - fitted(object, h=h)
 }
 
-residuals.stlm <- function(object, type=c("innovation","response"), ...) 
+residuals.stlm <- function(object, type=c("innovation","response"), ...)
 {
   type <- match.arg(type)
   if(type=="innovation")
@@ -109,4 +112,3 @@ residuals.stlm <- function(object, type=c("innovation","response"), ...)
   else
     getResponse(object) - fitted(object)
 }
-

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -97,7 +97,7 @@ residuals.nnetar <- function(object, type=c("innovation","response"), h=1, ...)
   type <- match.arg(type)
   if(type=="innovation" & !is.null(object$lambda))
     if(!is.null(object$scalex$scale))
-      na.omit(rowMeans(sapply(object$model, residuals)))/object$scalex$scale
+      na.omit(rowMeans(sapply(object$model, residuals)))*object$scalex$scale
     else
       na.omit(rowMeans(sapply(object$model, residuals)))
   else

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -198,7 +198,7 @@ myarima.sim <- function (model, n, x, e, ...)
     delta.four <- diff(data, lag=m, differences=D)
     regular.xi <- delta.four[(length(delta.four)-D):length(delta.four)]
     x <- diffinv(x, differences = d, xi=regular.xi[length(regular.xi)-(d:1)+1])[-(1:d)]
- 
+
     #Then seasonal
     i <- length(data) - D*m + 1
     seasonal.xi <- data[i:length(data)]
@@ -423,7 +423,7 @@ simulate.ar <- function(object, nsim=object$n.used, seed=NULL, future=TRUE, boot
   }
   else
     nsim <- length(innov)
- 
+
   if(future)
   {
       model <- list(ar=object$ar,sd=sqrt(object$var.pred),residuals=object$resid, seasonal.difference=0, seasonal.period=1, flag.seasonal.arma=FALSE)
@@ -503,15 +503,19 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
   ## set simulation innovations
   if(bootstrap)
   {
-#    res <- na.omit(residuals(object, type="innovation"))/object$scalex$scale
-    res <- na.omit(rowMeans(sapply(object$model, residuals)))
+    res <- na.omit(residuals(object, type="innovation"))
     res <- res - mean(res)
+    ## scale if appropriate
+    if(!is.null(object$scalex$scale))
+      res <- res/object$scalex$scale
     e <- sample(res,nsim,replace=TRUE)
   }
   else if(is.null(innov))
   {
-#    res <- na.omit(residuals(object, type="innovation"))/object$scalex$scale
-    res <- na.omit(rowMeans(sapply(object$model, residuals)))
+    res <- na.omit(residuals(object, type="innovation"))
+    ## scale if appropriate
+    if(!is.null(object$scalex$scale))
+      res <- res/object$scalex$scale
     e <- rnorm(nsim, 0, sd(res, na.rm=TRUE))
   }
   else if(length(innov)==nsim)


### PR DESCRIPTION
The residuals in `object$residuals` for `nnetar` correspond to the difference between the fitted values and the original series. I modified the code to get the actual white noise residuals from the fitted `nnet` models (but only when necessary, meaning the user requests "innovations" _and_ `lambda` is not NULL).

I also updated `simulate.nnetar` to use the new `residuals` method, for both clarity and efficiency.