### PR TITLE
Improved default autoplot.mts interaction when setting facets=TRUE

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1247,7 +1247,7 @@ autoplot.mts <- function(object, colour=TRUE, facets=FALSE, ...){
     
     #Initialise ggplot object
     mapping <- ggplot2::aes_(y=~y, x=~x, group=~series)
-    if(colour){
+    if (colour & (!facets | !missing(colour))){
       mapping$colour <- quote(series)
     }
     p <- ggplot2::ggplot(mapping, data=data)

--- a/man/autoplot.ts.Rd
+++ b/man/autoplot.ts.Rd
@@ -15,7 +15,7 @@
 \arguments{
 \item{object}{Object of class \dQuote{ts} or \dQuote{mts}.}
 \item{series}{Identifies the timeseries with a colour, which integrates well with the functionality of \link{geom_forecast}.}
-\item{facets}{If TRUE, multiple time series will be faceted. If FALSE, each series will be assigned a colour.}
+\item{facets}{If TRUE, multiple time series will be faceted (and unless specified, colour is set to FALSE). If FALSE, each series will be assigned a colour.}
 \item{colour}{If TRUE, the time series will be assigned a colour aesthetic}
 \item{model}{Object of class \dQuote{ts} to be converted to \dQuote{data.frame}.}
 \item{data}{Not used (required for \link{fortify} method)}


### PR DESCRIPTION
Now when `facets=TRUE`, `colour=FALSE`, unless specified directly with `autoplot(mts, colour=TRUE, facets=TRUE)`