### PR TITLE
Fixing #561 by subsetting in vectorized way

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -47,7 +47,7 @@ testaccuracy <- function(f,x,test,d,D)
   ff <- f
   xx <- x
 
-  error <- (xx-ff[1:n])[test]
+  error <- (xx-rep(ff, length.out = n))[test]
   pe <- error/xx[test] * 100
 
   me <- mean(error, na.rm=TRUE)


### PR DESCRIPTION
This pull request fixes #561 partially as it does *not* validate the input data.

Moreover, it assumes that the shorter `f` vector should be "extended" to have equal length as `x`. Such behavior leads to other possible problems: it could lead to incorrect results when `f` was shorter by mistake. I leave it to your consideration if such behavior should happen with warning, or if it should not be allowed and it should throw error when validating the input data. As I suggested, I feel that for `length(f) == 1` this should be implemented (possibly with warning).

This is also a fix for the "general" accuracy measures, similar fixes need to be included in other parts of the code as well (but the fixes are less obvious in other cases).