### PR TITLE
Accept ts based on 1-dim array

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -38,7 +38,7 @@ na.interp <- function(x, lambda=NULL)
   # Convert to ts
   if(is.null(tsp(x)))
     x <- ts(x)
-  if(!is.null(dim(x)))
+  if(length(dim(x)) > 1)
     stop("The time series is not univariate.")
 
   #Transform if requested


### PR DESCRIPTION
Previous behavior:
> na.interp(ts(array(c(rnorm(100), NA, rnorm(100)))))
Error in na.interp(ts(array(c(rnorm(100), NA, rnorm(100))))) : 
  The time series is not univariate.