### PR TITLE
Pick up biasadj from existing Arima model

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -777,8 +777,10 @@ Arima <- function(y, order=c(0, 0, 0), seasonal=c(0, 0, 0), xreg=NULL, include.m
 
   origx <- y
   if(!is.null(lambda)){
-    x <- BoxCox(x,lambda)
-    attr(lambda, "biasadj") <- biasadj
+    x <- BoxCox(x, lambda)
+	  
+    if(is.null(attr(lambda, "biasadj"))
+      attr(lambda, "biasadj") <- biasadj
   }
 
   if (!is.null(xreg))


### PR DESCRIPTION
Currently if an existing model has the bias adjustment parameter set, then this is dropped when passing the model to Arima. This change checks if the lambda already has a bias adjustment set (since lambda parameter defaults to coming from the original model). Not sure if this change should be implemented in arima2 instead.