### PR TITLE
Protect thetaf from constant series

### DIFF
--- a/R/theta.R
+++ b/R/theta.R
@@ -82,7 +82,7 @@ thetaf <- function(y, h=ifelse(frequency(y)>1, 2*frequency(y), 10),
   n <- length(x)
   x <- as.ts(x)
   m <- frequency(x)
-  if(m > 1)
+  if(m > 1 & !is.constant(x))
   {
     r <- as.numeric(acf(x, lag.max=m, plot=FALSE)$acf)[-1]
     stat <- sqrt((1 + 2*sum(r[-m]^2)) / n)

--- a/tests/testthat/test-forecast2.R
+++ b/tests/testthat/test-forecast2.R
@@ -10,6 +10,10 @@ if(require(testthat))
     expect_true(all(meanf(wineind, fan = TRUE)$mean == meanfc))
     expect_error(meanf(wineind, level = -10))
     expect_error(meanf(wineind, level = 110))
+    # Constant series should not error
+    series <- ts(rep(950, 20), f = 4)
+    constantForecast <- expect_error(rwf(series), NA)
+    expect_true(is.constant(constantForecast$mean))
   })
 
   test_that("test rwf()", {
@@ -19,6 +23,10 @@ if(require(testthat))
     expect_true(all(rwf(airmiles, fan = TRUE)$mean == rwfc))
     expect_true(length(rwf(airmiles, lambda = 0.15)$mean) == 10)
     expect_false(identical(rwf(airmiles, lambda = 0.15, biasadj = FALSE)$mean, rwf(airmiles, lambda = 0.15, biasadj = TRUE)$mean))
+    # Constant series should not error
+    series <- ts(rep(950, 20), f = 4)
+    constantForecast <- expect_error(rwf(series), NA)
+    expect_true(is.constant(constantForecast$mean))
   })
 
   test_that("test forecast.HoltWinters()", {
@@ -72,5 +80,9 @@ if(require(testthat))
     expect_true(all(snaive(WWWusage, h = 10)$mean == naive(WWWusage)$mean))
     expect_true(all(snaive(WWWusage, h = 10)$upper == naive(WWWusage)$upper))
     expect_true(all(snaive(WWWusage, h = 10)$lower == naive(WWWusage)$lower))
+    # Constant series should not error
+    series <- ts(rep(950, 20), f = 4)
+    constantForecast <- expect_error(snaive(series), NA)
+    expect_true(is.constant(constantForecast$mean))
   })
 }

--- a/tests/testthat/test-forecast2.R
+++ b/tests/testthat/test-forecast2.R
@@ -12,13 +12,6 @@ if(require(testthat))
     expect_error(meanf(wineind, level = 110))
   })
 
-  test_that("test thetaf()", {
-    thetafc <- thetaf(WWWusage)$mean
-    expect_true(all(thetafc == thetaf(WWWusage, fan = TRUE)$mean))
-    expect_error(thetaf(WWWusage, level = -10))
-    expect_error(thetaf(WWWusage, level = 110))
-  })
-
   test_that("test rwf()", {
     rwfc <- rwf(airmiles)$mean
     expect_true(all(rwfc == naive(airmiles)$mean))

--- a/tests/testthat/test-season.R
+++ b/tests/testthat/test-season.R
@@ -67,7 +67,8 @@ if(require(testthat))
   # Constant series should not error
   series <- ts(rep(950, 20), f = 4)
   constantForecast <- expect_error(stlf(series), NA)
-  expect_true(is.constant(constantForecast$mean))
+  # Small eps
+  expect_true(all(abs(constantForecast$mean - mean(series)) < 10^-8))
   })
 
   test_that("tests for ma",{

--- a/tests/testthat/test-season.R
+++ b/tests/testthat/test-season.R
@@ -64,6 +64,10 @@ if(require(testthat))
   fit1 <- stlf(wineind,lambda=.2,biasadj=FALSE)
   fit2 <- stlf(wineind,lambda=.2,biasadj=TRUE)
   expect_false(identical(fit1$mean, fit2$mean))
+  # Constant series should not error
+  series <- ts(rep(950, 20), f = 4)
+  constantForecast <- expect_error(stlf(series), NA)
+  expect_true(is.constant(constantForecast$mean))
   })
 
   test_that("tests for ma",{

--- a/tests/testthat/test-thetaf.R
+++ b/tests/testthat/test-thetaf.R
@@ -1,0 +1,14 @@
+# A unit test for thetaf.R
+if(require(testthat))
+{
+  test_that("test thetaf()", {
+    thetafc <- thetaf(WWWusage)$mean
+    expect_true(all(thetafc == thetaf(WWWusage, fan = TRUE)$mean))
+    expect_error(thetaf(WWWusage, level = -10))
+    expect_error(thetaf(WWWusage, level = 110))
+    # Constant series should not error
+    series <- ts(rep(950, 20), f = 4)
+    thetaConstant <- expect_error(thetaf(series), NA)
+    expect_true(is.constant(thetaConstant$mean))
+  })
+}

--- a/tests/testthat/test-thetaf.R
+++ b/tests/testthat/test-thetaf.R
@@ -8,7 +8,7 @@ if(require(testthat))
     expect_error(thetaf(WWWusage, level = 110))
     # Constant series should not error
     series <- ts(rep(950, 20), f = 4)
-    thetaConstant <- expect_error(thetaf(series), NA)
-    expect_true(is.constant(thetaConstant$mean))
+    constantForecast <- expect_error(thetaf(series), NA)
+    expect_true(is.constant(constantForecast$mean))
   })
 }


### PR DESCRIPTION
This looks like a corner case where the theta model fails on a constant series
```
> data <- ts(c(950,950,950,950,950,950,950,950,950,950,950,950,950,950,950,950,950,950,950,950), f = 4)
> thetaf(data)
Error in if (seasonal) { : missing value where TRUE/FALSE needed
```
It appears line 89 of `theta.R`  needs to be protected from `NA`.

This PR adds that protection and tests for this (and other forecast functions like `rwf()`, `meanf()`, etc) to the test suite.


FYI, `devtools::test()` is throwing some errors/warnings unrelated to this on my machine:
```
> test()
Loading forecast
Loading required package: testthat

Attaching package: ‘testthat’

The following object is masked from ‘package:devtools’:

    setup

This is forecast 8.3 
  Want to meet other forecasters? Join the International Institute of Forecasters:
  http://forecasters.org/
Testing forecast
✔ | OK F W S | Context
✔ |  1       | Tests on input
✔ |  7       | Tests on output [1.3 s]
✔ | 74       | Tests on input [7.5 s]
✔ |  1       | Testing armaroots
✔ |  6       | Tests on input and output [1.8 s]
✔ |  7       | Tests for biasadj [0.8 s]
✔ |  7       | Testing calendar functions [3.0 s]
✔ |  6       | Tests on dshw() [8.2 s]ons
✔ | 19       | Tests on input [1.8 s]
✔ |  7       | Test forecast.R [0.3 s]
✔ | 34   1   | Test forecast2.R [0.9 s]
────────────────────────────────────────────────────────────────────────────────
test-forecast2.R:39: warning: test forecast.HoltWinters()
optimization difficulties: ERROR: ABNORMAL_TERMINATION_IN_LNSRCH
────────────────────────────────────────────────────────────────────────────────
✔ |  3       | forecast ggplot tests [4.8 s]
✔ |  1     1 | Testing graph [0.4 s]
────────────────────────────────────────────────────────────────────────────────
test-graph.R:15: skip: Tests for tsdisplay()
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  5       | Tests for h-step fits with hfitted [2.6 s]
✖ | 13 1   1 | Test mforecast.R [2.4 s]
────────────────────────────────────────────────────────────────────────────────
test-mforecast.R:27: failure: tests for mlmsplit()
fit2$coefficients not identical to fit4$coefficients.
Objects equal but not identical

test-mforecast.R:59: skip: tests for plot.mforecast()
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  1       | Test msts.R
✔ | 36       | Testing nnetar [2.0 s]
✔ | 68       | Re-fitting models [10.9 s]
✔ |  4       | Testing splinef() [0.6 s]
✔ | 24       | Tests on input
✔ | 21     1 | Tests on tbats() functions [9.7 s]
────────────────────────────────────────────────────────────────────────────────
test-tbats.R:49: skip: Test tbats() with parallel
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ | 28     1 | Tests on building model in tslm [0.1 s]
────────────────────────────────────────────────────────────────────────────────
test-tslm.R:82: skip: Unusual usage
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  8       | Tests joining data.frames

══ Results ═════════════════════════════════════════════════════════════════════
Duration: 64.3 s

OK:       456
Failed:   2
Warnings: 1
Skipped:  4
Warning message:
`encoding` is deprecated; all files now assumed to be UTF-8 
> 
> test()
Loading forecast
Testing forecast
✔ | OK F W S | Context
✔ |  1       | Tests on input
✔ |  7       | Tests on output [0.7 s]
✔ | 74       | Tests on input [7.2 s]
✔ |  1       | Testing armaroots
✔ |  6       | Tests on input and output [1.5 s]
✔ |  7       | Tests for biasadj [0.6 s]
✔ |  7       | Testing calendar functions [2.5 s]
✔ |  6       | Tests on dshw() [8.4 s]ons
✔ | 19       | Tests on input [1.9 s]
✔ |  7       | Test forecast.R [0.1 s]
✔ | 34   1   | Test forecast2.R [0.8 s]
────────────────────────────────────────────────────────────────────────────────
test-forecast2.R:39: warning: test forecast.HoltWinters()
optimization difficulties: ERROR: ABNORMAL_TERMINATION_IN_LNSRCH
────────────────────────────────────────────────────────────────────────────────
✔ |  3       | forecast ggplot tests [3.7 s]
✔ |  1     1 | Testing graph [0.3 s]
────────────────────────────────────────────────────────────────────────────────
test-graph.R:15: skip: Tests for tsdisplay()
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  5       | Tests for h-step fits with hfitted [2.7 s]
✖ | 13 1   1 | Test mforecast.R [2.3 s]
────────────────────────────────────────────────────────────────────────────────
test-mforecast.R:27: failure: tests for mlmsplit()
fit2$coefficients not identical to fit4$coefficients.
Objects equal but not identical

test-mforecast.R:59: skip: tests for plot.mforecast()
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  1       | Test msts.R
✔ | 36       | Testing nnetar [2.0 s]
✔ | 68       | Re-fitting models [11.5 s]
✔ |  4       | Testing splinef() [0.5 s]
✔ | 24       | Tests on input
✔ | 21     1 | Tests on tbats() functions [11.0 s]
────────────────────────────────────────────────────────────────────────────────
test-tbats.R:49: skip: Test tbats() with parallel
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ | 28     1 | Tests on building model in tslm [0.1 s]
────────────────────────────────────────────────────────────────────────────────
test-tslm.R:82: skip: Unusual usage
Empty test
────────────────────────────────────────────────────────────────────────────────
✔ |  8       | Tests joining data.frames

══ Results ═════════════════════════════════════════════════════════════════════
Duration: 61.9 s

OK:       458
Failed:   2
Warnings: 1
Skipped:  4
Warning message:
`encoding` is deprecated; all files now assumed to be UTF-8 
```