### PR TITLE
Use long-form && || in if/while's where appt

### DIFF
--- a/R/HoltWintersNew.R
+++ b/R/HoltWintersNew.R
@@ -210,7 +210,7 @@ HoltWintersZZ <- function(x,
     components <- c("A", trendtype, seasontype, damped)
   } else if (seasonal == "multiplicative") {
     components <- c("M", trendtype, seasontype, damped)
-  } else if (seasonal == "none" & exponential) {
+  } else if (seasonal == "none" && exponential) {
     components <- c("M", trendtype, seasontype, damped)
   } else { # if(seasonal=="none" & !exponential)
     components <- c("A", trendtype, seasontype, damped)
@@ -479,7 +479,7 @@ holt <- function(y, h = 10, damped = FALSE, level = c(80, 95), fan = FALSE,
   if (length(y) <= 1L) {
     stop("I need at least two observations to estimate trend.")
   }
-  if (initial == "optimal" | damped) {
+  if (initial == "optimal" || damped) {
     if (exponential) {
       fcast <- forecast(ets(x, "MMN", alpha = alpha, beta = beta, phi = phi, damped = damped, opt.crit = "mse", lambda = lambda, biasadj = biasadj), h, level = level, fan = fan, ...)
     } else {
@@ -525,12 +525,12 @@ hw <- function(y, h = 2 * frequency(x), seasonal = c("additive", "multiplicative
   if (length(y) < m + 3) {
     stop(paste("I need at least", m + 3, "observations to estimate seasonality."))
   }
-  if (initial == "optimal" | damped) {
-    if (seasonal == "additive" & exponential) {
+  if (initial == "optimal" || damped) {
+    if (seasonal == "additive" && exponential) {
       stop("Forbidden model combination")
-    } else if (seasonal == "additive" & !exponential) {
+    } else if (seasonal == "additive" && !exponential) {
       fcast <- forecast(ets(x, "AAA", alpha = alpha, beta = beta, gamma = gamma, phi = phi, damped = damped, opt.crit = "mse", lambda = lambda, biasadj = biasadj), h, level = level, fan = fan, ...)
-    } else if (seasonal != "additive" & exponential) {
+    } else if (seasonal != "additive" && exponential) {
       fcast <- forecast(ets(x, "MMM", alpha = alpha, beta = beta, gamma = gamma, phi = phi, damped = damped, opt.crit = "mse", lambda = lambda, biasadj = biasadj), h, level = level, fan = fan, ...)
     } else { # if(seasonal!="additive" & !exponential)
       fcast <- forecast(ets(x, "MAM", alpha = alpha, beta = beta, gamma = gamma, phi = phi, damped = damped, opt.crit = "mse", lambda = lambda, biasadj = biasadj), h, level = level, fan = fan, ...)

--- a/R/acf.R
+++ b/R/acf.R
@@ -161,14 +161,14 @@ seasonalaxis <- function(frequency, nlags, type, plot=TRUE) {
     }
 
     if (frequency == 1) {
-      if (type == "acf" & nlags <= 16) {
+      if (type == "acf" && nlags <= 16) {
         out <- 1:nlags
-      } else if (type == "ccf" & nlags <= 8) {
+      } else if (type == "ccf" && nlags <= 8) {
         out <- (-nlags:nlags)
       } else {
-        if (nlags <= 30 & type == "acf") {
+        if (nlags <= 30 && type == "acf") {
           out2 <- 1:nlags
-        } else if (nlags <= 15 & type == "ccf") {
+        } else if (nlags <= 15 && type == "ccf") {
           out2 <- (-nlags:nlags)
         }
         if (!is.null(out2)) {
@@ -176,21 +176,21 @@ seasonalaxis <- function(frequency, nlags, type, plot=TRUE) {
         }
       }
     }
-    else if (frequency > 1 &
-      ((type == "acf" & np >= 2L) | (type == "ccf" & np >= 1L))) {
-      if (type == "acf" & nlags <= 40) {
+    else if (frequency > 1 &&
+      ((type == "acf" && np >= 2L) || (type == "ccf" && np >= 1L))) {
+      if (type == "acf" && nlags <= 40) {
         out <- frequency * (1:np)
         out2 <- 1:nlags
         # Add half-years
-        if (nlags <= 30 & evenfreq & np <= 3) {
+        if (nlags <= 30 && evenfreq && np <= 3) {
           out <- c(out, frequency * ((1:np) - 0.5))
         }
       }
-      else if (type == "ccf" & nlags <= 20) {
+      else if (type == "ccf" && nlags <= 20) {
         out <- frequency * (-np:np)
         out2 <- (-nlags:nlags)
         # Add half-years
-        if (nlags <= 15 & evenfreq & np <= 3) {
+        if (nlags <= 15 && evenfreq && np <= 3) {
           out <- c(out, frequency * ((-np:np) + 0.5))
         }
       }
@@ -322,7 +322,7 @@ wacf <- function(x, lag.max = length(x) - 1) {
   l <- 0
   k <- 1
   N <- length(j) - 4
-  while (l < 1 & k <= N) {
+  while (l < 1 && k <= N) {
     if (all(j[k:(k + 4)])) {
       l <- k
     } else {

--- a/R/adjustSeasonalSeeds.R
+++ b/R/adjustSeasonalSeeds.R
@@ -60,7 +60,7 @@ cutW <- function(use.beta, w.tilda.transpose, seasonal.periods, p=0, q=0) {
       for (j in (s - 1):1) {
         hcf <- findGCD(seasonal.periods[s], seasonal.periods[j])
         if (hcf != 1) {
-          if ((mask.vector[s] != 1) & (mask.vector[j] != 1)) {
+          if ((mask.vector[s] != 1) && (mask.vector[j] != 1)) {
             mask.vector[s] <- hcf * -1
           }
         }

--- a/R/arfima.R
+++ b/R/arfima.R
@@ -282,9 +282,9 @@ forecast.fracdiff <- function(object, h=10, level=c(80, 95), fan=FALSE, lambda=o
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }

--- a/R/armaroots.R
+++ b/R/armaroots.R
@@ -127,7 +127,7 @@ plot.Arima <- function(x, type=c("both", "ar", "ma"), main,
     }
   }
 
-  if (p == 0 & q == 0) {
+  if (p == 0 && q == 0) {
     stop("No roots to plot")
   }
   # Check for MA parts
@@ -138,7 +138,7 @@ plot.Arima <- function(x, type=c("both", "ar", "ma"), main,
       type <- "ar"
     }
   }
-  if ((type == "ar" & (p == 0)) | (type == "ma" & (q == 0))) {
+  if ((type == "ar" && (p == 0)) || (type == "ma" && (q == 0))) {
     stop("No roots to plot")
   }
 

--- a/R/bats.R
+++ b/R/bats.R
@@ -129,8 +129,8 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
     use.box.cox <- FALSE
   }
 
-  if ((!is.null(use.box.cox)) & (!is.null(use.trend)) & (use.parallel)) {
-    if ((use.trend == TRUE) & (!is.null(use.damped.trend))) {
+  if ((!is.null(use.box.cox)) && (!is.null(use.trend)) && (use.parallel)) {
+    if (use.trend && (!is.null(use.damped.trend))) {
       # In the this case, there is only one alternative.
       use.parallel <- FALSE
     }
@@ -145,7 +145,7 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
     seasonal.periods <- seasonal.periods[!seasonal.mask]
   }
   # Check if there is anything to parallelise
-  if (is.null(seasonal.periods) & !is.null(use.box.cox) & !is.null(use.trend)) {
+  if (is.null(seasonal.periods) && !is.null(use.box.cox) && !is.null(use.trend)) {
     use.parallel <- FALSE
   }
 
@@ -180,7 +180,7 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
       {
         for (damping in use.damped.trend)
         {
-          if ((trend == FALSE) & (damping == TRUE)) {
+          if (!trend && damping) {
             next
           }
           control.line <- c(box.cox, trend, damping)
@@ -244,13 +244,13 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
 
 filterSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, use.arma.errors,
                             force.seasonality=FALSE, init.box.cox=NULL, bc.lower=0, bc.upper=1, biasadj=FALSE, ...) {
-  if ((trend == FALSE) & (damping == TRUE)) {
+  if (!trend && damping) {
     return(list(AIC = Inf))
   }
 
 
   first.model <- fitSpecificBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = seasonal.periods, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj)
-  if ((!is.null(seasonal.periods)) & (!force.seasonality)) {
+  if (!is.null(seasonal.periods) && !force.seasonality) {
     non.seasonal.model <- fitSpecificBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = NULL, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj)
     if (first.model$AIC > non.seasonal.model$AIC) {
       seasonal.periods <- NULL
@@ -261,7 +261,7 @@ filterSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, use.ar
     suppressWarnings(arma <- auto.arima(as.numeric(first.model$errors), d = 0, ...))
     p <- arma$arma[1]
     q <- arma$arma[2]
-    if ((p != 0) | (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
+    if (p != 0 || q != 0) { # Did auto.arima() find any AR() or MA() coefficients?
       if (p != 0) {
         ar.coefs <- numeric(p)
       } else {
@@ -294,13 +294,13 @@ parFilterSpecifics <- function(control.number, control.array, y, seasonal.period
   damping <- control.array[control.number, 3]
 
 
-  if ((trend == FALSE) & (damping == TRUE)) {
+  if (!trend && damping) {
     return(list(AIC = Inf))
   }
 
 
   first.model <- fitSpecificBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = seasonal.periods, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj)
-  if ((!is.null(seasonal.periods)) & (!force.seasonality)) {
+  if (!is.null(seasonal.periods) && !force.seasonality) {
     non.seasonal.model <- fitSpecificBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = NULL, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj)
     if (first.model$AIC > non.seasonal.model$AIC) {
       seasonal.periods <- NULL
@@ -311,7 +311,7 @@ parFilterSpecifics <- function(control.number, control.array, y, seasonal.period
     suppressWarnings(arma <- auto.arima(as.numeric(first.model$errors), d = 0, ...))
     p <- arma$arma[1]
     q <- arma$arma[2]
-    if ((p != 0) | (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
+    if (p != 0 || q != 0) { # Did auto.arima() find any AR() or MA() coefficients?
       if (p != 0) {
         ar.coefs <- numeric(p)
       } else {

--- a/R/clean.R
+++ b/R/clean.R
@@ -63,7 +63,7 @@ na.interp <- function(x, lambda=NULL) {
   tt <- 1:n
   idx <- tt[!missng]
 
-  if (freq <= 1 | n <= 2 * freq) # Non-seasonal -- use linear interpolation
+  if (freq <= 1 || n <= 2 * freq) # Non-seasonal -- use linear interpolation
   {
     x <- ts(approx(idx, x[idx], tt, rule = 2)$y)
   }
@@ -188,7 +188,7 @@ tsoutliers <- function(x, iterate=2, lambda=NULL) {
   }
 
   # Seasonally adjust data if necessary
-  if (freq > 1 & n > 2 * freq) { 
+  if (freq > 1 && n > 2 * freq) { 
     fit <- mstl(xx, robust=TRUE)
     # Check if seasonality is sufficient to warrant adjustment
     rem <- remainder(fit)

--- a/R/dshw.r
+++ b/R/dshw.r
@@ -94,10 +94,10 @@ dshw <- function(y, period1=NULL, period2=NULL, h=2 * max(period1, period2),
   if (!is.null(model) && model$method == "DSHW") {
     period1 <- model$period1
     period2 <- model$period2
-  } else if (any(class(y) == "msts") & (length(attr(y, "msts")) == 2)) {
+  } else if (inherits(y, "msts") && (length(attr(y, "msts")) == 2)) {
     period1 <- as.integer(sort(attr(y, "msts"))[1])
     period2 <- as.integer(sort(attr(y, "msts"))[2])
-  } else if (is.null(period1) | is.null(period2)) {
+  } else if (is.null(period1) || is.null(period2)) {
     stop("Error in dshw(): y must either be an msts object with two seasonal periods OR the seasonal periods should be specified with period1= and period2=")
   } else {
     if (period1 > period2) {
@@ -118,7 +118,7 @@ dshw <- function(y, period1=NULL, period2=NULL, h=2 * max(period1, period2),
     phi <- 0
   }
 
-  if (period1 < 1 | period1 == period2) {
+  if (period1 < 1 || period1 == period2) {
     stop("Inappropriate periods")
   }
   ratio <- period2 / period1

--- a/R/errors.R
+++ b/R/errors.R
@@ -22,7 +22,7 @@ testaccuracy <- function(f, x, test, d, D) {
       stop("Unknown list structure")
     }
   }
-  if (is.ts(x) & is.ts(f)) {
+  if (is.ts(x) && is.ts(f)) {
     tspf <- tsp(f)
     tspx <- tsp(x)
     start <- max(tspf[1], tspx[1])
@@ -36,7 +36,7 @@ testaccuracy <- function(f, x, test, d, D) {
   n <- length(x)
   if (is.null(test)) {
     test <- 1:n
-  } else if (min(test) < 1 | max(test) > n) {
+  } else if (min(test) < 1 || max(test) > n) {
     warning("test elements must be within sample")
     test <- test[test >= 1 & test <= n]
   }
@@ -84,7 +84,7 @@ testaccuracy <- function(f, x, test, d, D) {
   }
 
   # Additional time series measures
-  if (!is.null(tsp(x)) & n > 1) {
+  if (!is.null(tsp(x)) && n > 1) {
     fpe <- (c(ff[2:n]) / c(xx[1:(n - 1)]) - 1)[test - 1]
     ape <- (c(xx[2:n]) / c(xx[1:(n - 1)]) - 1)[test - 1]
     theil <- sqrt(sum((fpe - ape) ^ 2, na.rm = TRUE) / sum(ape ^ 2, na.rm = TRUE))
@@ -118,7 +118,7 @@ trainingaccuracy <- function(f, test, d, D) {
   if (is.null(test)) {
     test <- 1:n
   }
-  if (min(test) < 1 | max(test) > n) {
+  if (min(test) < 1 || max(test) > n) {
     warning("test elements must be within sample")
     test <- test[test >= 1 & test <= n]
   }
@@ -259,15 +259,15 @@ accuracy.default <- function(f, x, test=NULL, d=NULL, D=NULL, ...) {
 
   trainset <- (is.list(f))
   testset <- (!missing(x))
-  if (testset & !is.null(test)) {
+  if (testset && !is.null(test)) {
     trainset <- FALSE
   }
-  if (!trainset & !testset) {
+  if (!trainset && !testset) {
     stop("Unable to compute forecast accuracy measures")
   }
 
   # Find d and D
-  if (is.null(D) & is.null(d)) {
+  if (is.null(D) && is.null(d)) {
     if (testset) {
       d <- as.numeric(frequency(x) == 1)
       D <- as.numeric(frequency(x) > 1)

--- a/R/ets.R
+++ b/R/ets.R
@@ -109,7 +109,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
   y <- as.ts(y)
 
   # Check if data is constant
-  if (missing(model) & is.constant(y)) {
+  if (missing(model) && is.constant(y)) {
     return(ses(y, alpha = 0.99999, initial = "simple")$model)
   }
 
@@ -121,7 +121,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
   }
 
   orig.y <- y
-  if (class(model) == "ets" & is.null(lambda)) {
+  if (identical(class(model), "ets") && is.null(lambda)) {
     lambda <- model$lambda
   }
   if (!is.null(lambda)) {
@@ -129,7 +129,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
     additive.only <- TRUE
   }
 
-  if (nmse < 1 | nmse > 30) {
+  if (nmse < 1 || nmse > 30) {
     stop("nmse out of range")
   }
   m <- frequency(y)
@@ -223,12 +223,12 @@ ets <- function(y, model="ZZZ", damped=NULL,
     stop("Invalid season type")
   }
 
-  if (m < 1 | length(y) <= m) {
+  if (m < 1 || length(y) <= m) {
     # warning("I can't handle data with frequency less than 1. Seasonality will be ignored.")
     seasontype <- "N"
   }
   if (m == 1) {
-    if (seasontype == "A" | seasontype == "M") {
+    if (seasontype == "A" || seasontype == "M") {
       stop("Nonseasonal data")
     } else {
       substr(model, 3, 3) <- seasontype <- "N"
@@ -246,21 +246,21 @@ ets <- function(y, model="ZZZ", damped=NULL,
 
   # Check inputs
   if (restrict) {
-    if ((errortype == "A" & (trendtype == "M" | seasontype == "M")) |
-      (errortype == "M" & trendtype == "M" & seasontype == "A") |
-      (additive.only & (errortype == "M" | trendtype == "M" | seasontype == "M"))) {
+    if ((errortype == "A" && (trendtype == "M" || seasontype == "M")) |
+      (errortype == "M" && trendtype == "M" && seasontype == "A") ||
+      (additive.only && (errortype == "M" || trendtype == "M" || seasontype == "M"))) {
       stop("Forbidden model combination")
     }
   }
 
   data.positive <- (min(y) > 0)
 
-  if (!data.positive & errortype == "M") {
+  if (!data.positive && errortype == "M") {
     stop("Inappropriate model for data with negative or zero values")
   }
 
   if (!is.null(damped)) {
-    if (damped & trendtype == "N") {
+    if (damped && trendtype == "N") {
       stop("Forbidden model combination")
     }
   }
@@ -268,10 +268,10 @@ ets <- function(y, model="ZZZ", damped=NULL,
   n <- length(y)
   # Check we have enough data to fit a model
   npars <- 2L # alpha + l0
-  if (trendtype == "A" | trendtype == "M") {
+  if (trendtype == "A" || trendtype == "M") {
     npars <- npars + 2L
   } # beta + b0
-  if (seasontype == "A" | seasontype == "M") {
+  if (seasontype == "A" || seasontype == "M") {
     npars <- npars + m
   } # gamma + s
   if (!is.null(damped)) {
@@ -285,7 +285,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
         warning("Not enough data to use damping")
       }
     }
-    if (seasontype == "A" | seasontype == "M") {
+    if (seasontype == "A" || seasontype == "M") {
       fit <- try(HoltWintersZZ(
         orig.y,
         alpha = alpha, beta = beta, gamma = gamma, phi = phi,
@@ -303,7 +303,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
         warning("Seasonal component could not be estimated")
       }
     }
-    if (trendtype == "A" | trendtype == "M") {
+    if (trendtype == "A" || trendtype == "M") {
       fit <- try(HoltWintersZZ(
         orig.y,
         alpha = alpha, beta = beta, gamma = FALSE, phi = phi,
@@ -320,7 +320,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
         warning("Trend component could not be estimated")
       }
     }
-    if (trendtype == "N" & seasontype == "N") {
+    if (trendtype == "N" && seasontype == "N") {
       fit <- try(HoltWintersZZ(
         orig.y,
         alpha = alpha, beta = FALSE, gamma = FALSE,
@@ -385,21 +385,21 @@ ets <- function(y, model="ZZZ", damped=NULL,
       {
         for (l in 1:length(damped))
         {
-          if (trendtype[j] == "N" & damped[l]) {
+          if (trendtype[j] == "N" && damped[l]) {
             next
           }
           if (restrict) {
-            if (errortype[i] == "A" & (trendtype[j] == "M" | seasontype[k] == "M")) {
+            if (errortype[i] == "A" && (trendtype[j] == "M" || seasontype[k] == "M")) {
               next
             }
-            if (errortype[i] == "M" & trendtype[j] == "M" & seasontype[k] == "A") {
+            if (errortype[i] == "M" && trendtype[j] == "M" && seasontype[k] == "A") {
               next
             }
-            if (additive.only & (errortype[i] == "M" | trendtype[j] == "M" | seasontype[k] == "M")) {
+            if (additive.only && (errortype[i] == "M" || trendtype[j] == "M" || seasontype[k] == "M")) {
               next
             }
           }
-          if (!data.positive & errortype[i] == "M") {
+          if (!data.positive && errortype[i] == "M") {
             next
           }
           fit <- etsmodel(
@@ -840,7 +840,7 @@ initparam <- function(alpha, beta, gamma, phi, trendtype, seasontype, damped, lo
   # Select alpha
   if (is.null(alpha)) {
     alpha <- lower[1] + 0.2 * (upper[1] - lower[1]) / m
-    if (alpha > 1 | alpha < 0) {
+    if (alpha > 1 || alpha < 0) {
       alpha <- lower[1] + 2e-3
     }
     par <- c(alpha = alpha)
@@ -850,31 +850,31 @@ initparam <- function(alpha, beta, gamma, phi, trendtype, seasontype, damped, lo
   }
 
   # Select beta
-  if (trendtype != "N" & is.null(beta)) {
+  if (trendtype != "N" && is.null(beta)) {
     # Ensure beta < alpha
     upper[2] <- min(upper[2], alpha)
     beta <- lower[2] + 0.1 * (upper[2] - lower[2])
-    if (beta < 0 | beta > alpha) {
+    if (beta < 0 || beta > alpha) {
       beta <- alpha - 1e-3
     }
     par <- c(par, beta = beta)
   }
 
   # Select gamma
-  if (seasontype != "N" & is.null(gamma)) {
+  if (seasontype != "N" && is.null(gamma)) {
     # Ensure gamma < 1-alpha
     upper[3] <- min(upper[3], 1 - alpha)
     gamma <- lower[3] + 0.05 * (upper[3] - lower[3])
-    if (gamma < 0 | gamma > 1 - alpha) {
+    if (gamma < 0 || gamma > 1 - alpha) {
       gamma <- 1 - alpha - 1e-3
     }
     par <- c(par, gamma = gamma)
   }
 
   # Select phi
-  if (damped & is.null(phi)) {
+  if (damped && is.null(phi)) {
     phi <- lower[4] + .99 * (upper[4] - lower[4])
-    if (phi < 0 | phi > 1) {
+    if (phi < 0 || phi > 1) {
       phi <- upper[4] - 1e-3
     }
     par <- c(par, phi = phi)
@@ -886,22 +886,22 @@ initparam <- function(alpha, beta, gamma, phi, trendtype, seasontype, damped, lo
 check.param <- function(alpha, beta, gamma, phi, lower, upper, bounds, m) {
   if (bounds != "admissible") {
     if (!is.null(alpha)) {
-      if (alpha < lower[1] | alpha > upper[1]) {
+      if (alpha < lower[1] || alpha > upper[1]) {
         return(0)
       }
     }
     if (!is.null(beta)) {
-      if (beta < lower[2] | beta > alpha | beta > upper[2]) {
+      if (beta < lower[2] || beta > alpha || beta > upper[2]) {
         return(0)
       }
     }
     if (!is.null(phi)) {
-      if (phi < lower[4] | phi > upper[4]) {
+      if (phi < lower[4] || phi > upper[4]) {
         return(0)
       }
     }
     if (!is.null(gamma)) {
-      if (gamma < lower[3] | gamma > 1 - alpha | gamma > upper[3]) {
+      if (gamma < lower[3] || gamma > 1 - alpha || gamma > upper[3]) {
         return(0)
       }
     }
@@ -985,7 +985,7 @@ initstate <- function(y, trendtype, seasontype) {
       if (abs(b0) > 1e10) { # Avoid infinite slopes
         b0 <- sign(b0) * 1e10
       }
-      if (l0 < 1e-8 | b0 < 1e-8) # Simple linear approximation didn't work.
+      if (l0 < 1e-8 || b0 < 1e-8) # Simple linear approximation didn't work.
       {
         l0 <- max(y.sa[1], 1e-3)
         b0 <- max(y.sa[2] / y.sa[1], 1e-3)
@@ -1199,15 +1199,15 @@ admissible <- function(alpha, beta, gamma, phi, m) {
   if (is.null(phi)) {
     phi <- 1
   }
-  if (phi < 0 | phi > 1 + 1e-8) {
+  if (phi < 0 || phi > 1 + 1e-8) {
     return(0)
   }
   if (is.null(gamma)) {
-    if (alpha < 1 - 1 / phi | alpha > 1 + 1 / phi) {
+    if (alpha < 1 - 1 / phi || alpha > 1 + 1 / phi) {
       return(0)
     }
     if (!is.null(beta)) {
-      if (beta < alpha * (phi - 1) | beta > (1 + phi) * (2 - alpha)) {
+      if (beta < alpha * (phi - 1) || beta > (1 + phi) * (2 - alpha)) {
         return(0)
       }
     }
@@ -1217,7 +1217,7 @@ admissible <- function(alpha, beta, gamma, phi, m) {
     if (is.null(beta)) {
       beta <- 0
     }
-    if (gamma < max(1 - 1 / phi - alpha, 0) | gamma > 1 + 1 / phi - alpha) {
+    if (gamma < max(1 - 1 / phi - alpha, 0) || gamma > 1 + 1 / phi - alpha) {
       return(0)
     }
     if (alpha < 1 - 1 / phi - gamma * (1 - m + phi + phi * m) / (2 * phi * m)) {
@@ -1278,7 +1278,7 @@ plot.ets <- function(x, ...) {
   } else {
     y <- x$x
   }
-  if (x$components[3] == "N" & x$components[2] == "N") {
+  if (x$components[3] == "N" && x$components[2] == "N") {
     plot(
       cbind(observed = y, level = x$states[, 1]),
       main = paste("Decomposition by", x$method, "method"), ...

--- a/R/etsforecast.R
+++ b/R/etsforecast.R
@@ -78,7 +78,7 @@ forecast.ets <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10),
       biasadj <- FALSE
     }
   }
-  if (!PI & !biasadj) {
+  if (!PI && !biasadj) {
     simulate <- bootstrap <- fan <- FALSE
     if (!biasadj) {
       npaths <- 2
@@ -88,9 +88,9 @@ forecast.ets <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10),
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -105,11 +105,11 @@ forecast.ets <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10),
 
   if (simulate) {
     f <- pegelsfcast.C(h, object, level = level, bootstrap = bootstrap, npaths = npaths)
-  } else if (object$components[1] == "A" & is.element(object$components[2], c("A", "N")) & is.element(object$components[3], c("N", "A"))) {
+  } else if (object$components[1] == "A" && is.element(object$components[2], c("A", "N")) && is.element(object$components[3], c("N", "A"))) {
     f <- class1(h, object$states[n + 1, ], object$components[2], object$components[3], damped, object$m, object$sigma2, object$par)
-  } else if (object$components[1] == "M" & is.element(object$components[2], c("A", "N")) & is.element(object$components[3], c("N", "A"))) {
+  } else if (object$components[1] == "M" && is.element(object$components[2], c("A", "N")) && is.element(object$components[3], c("N", "A"))) {
     f <- class2(h, object$states[n + 1, ], object$components[2], object$components[3], damped, object$m, object$sigma2, object$par)
-  } else if (object$components[1] == "M" & object$components[3] == "M" & object$components[2] != "M") {
+  } else if (object$components[1] == "M" && object$components[3] == "M" && object$components[2] != "M") {
     f <- class3(h, object$states[n + 1, ], object$components[2], object$components[3], damped, object$m, object$sigma2, object$par)
   } else {
     f <- pegelsfcast.C(h, object, level = level, bootstrap = bootstrap, npaths = npaths)
@@ -122,7 +122,7 @@ forecast.ets <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10),
     start.f <- length(object$x) + 1
   }
   out <- list(model = object, mean = ts(f$mu, frequency = object$m, start = start.f), level = level, x = object$x)
-  if (PI | biasadj) {
+  if (PI || biasadj) {
     if (!is.null(f$var)) {
       out$lower <- out$upper <- ts(matrix(NA, ncol = length(level), nrow = h))
       colnames(out$lower) <- colnames(out$upper) <- paste(level, "%", sep = "")

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -373,7 +373,7 @@ plot.forecast <- function(x, include, PI=TRUE, showgap = TRUE, shaded=TRUE, shad
   } else {
     xx <- NULL
   }
-  if (is.null(x$lower) | is.null(x$upper) | is.null(x$level)) {
+  if (is.null(x$lower) || is.null(x$upper) || is.null(x$level)) {
     PI <- FALSE
   }
   else if (!is.finite(max(x$upper))) {
@@ -391,7 +391,7 @@ plot.forecast <- function(x, include, PI=TRUE, showgap = TRUE, shaded=TRUE, shad
     x$lower <- as.matrix(x$lower)
   }
 
-  if (is.element("lm", class(x$model)) & !is.element("ts", class(x$mean))) # Non time series linear model
+  if (is.element("lm", class(x$model)) && !is.element("ts", class(x$mean))) # Non time series linear model
   {
     plotlmforecast(
       x, PI = PI, shaded = shaded, shadecols = shadecols, col = col, fcol = fcol, pi.col = pi.col, pi.lty = pi.lty,
@@ -512,7 +512,7 @@ plot.forecast <- function(x, include, PI=TRUE, showgap = TRUE, shaded=TRUE, shad
       }
     }
   }
-  if (npred > 1 & !shadebars & tsx) {
+  if (npred > 1 && !shadebars && tsx) {
     lines(pred.mean, lty = flty, lwd = flwd, col = fcol)
   } else {
     points(pred.mean, col = fcol, pch = 19)
@@ -659,7 +659,7 @@ as.data.frame.forecast <- function(x, ...) {
     attributes(out)$tsp <- attributes(x$mean)$tsp
   }
   names <- c("Point Forecast")
-  if (!is.null(x$lower) & !is.null(x$upper) & !is.null(x$level)) {
+  if (!is.null(x$lower) && !is.null(x$upper) && !is.null(x$level)) {
     x$upper <- as.matrix(x$upper)
     x$lower <- as.matrix(x$lower)
     for (i in 1:nconf)

--- a/R/forecast2.R
+++ b/R/forecast2.R
@@ -66,9 +66,9 @@ meanf <- function(y, h=10, level=c(80, 95), fan=FALSE, lambda=NULL, biasadj=FALS
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -202,7 +202,7 @@ InvBoxCox <- function(x, lambda, biasadj=FALSE, fvar=NULL) {
     }
     if (is.list(fvar)) { # Create fvar from forecast interval
       level <- max(fvar$level)
-      if (NCOL(fvar$upper) > 1 & NCOL(fvar$lower)) {
+      if (NCOL(fvar$upper) > 1 && NCOL(fvar$lower)) {
         i <- match(level, fvar$level)
         fvar$upper <- fvar$upper[, i]
         fvar$lower <- fvar$lower[, i]
@@ -230,7 +230,7 @@ InvBoxCoxf <- function(x=NULL, fvar=NULL, lambda=NULL) {
   }
   if (is.null(fvar)) {
     level <- max(x$level)
-    if (NCOL(x$upper) > 1 & NCOL(x$lower)) {
+    if (NCOL(x$upper) > 1 && NCOL(x$lower)) {
       i <- match(level, x$level)
       x$upper <- x$upper[, i]
       x$lower <- x$lower[, i]
@@ -309,9 +309,9 @@ forecast.StructTS <- function(object, h=ifelse(object$coef["epsilon"] > 1e-10, 2
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -417,9 +417,9 @@ forecast.HoltWinters <- function(object, h=ifelse(frequency(object$x) > 1, 2 * f
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -552,12 +552,12 @@ croston2 <- function(x, h=10, alpha=0.1, nofits=FALSE) {
     }
   }
   tt <- diff(c(0, (1:length(x))[x > 0])) # Times between non-zero observations
-  if (length(y) == 1 & length(tt) == 1) # Only one non-zero observation
+  if (length(y) == 1 && length(tt) == 1) # Only one non-zero observation
   {
     y.f <- list(mean = ts(rep(y, h), start = start.f, frequency = freq.x))
     p.f <- list(mean = ts(rep(tt, h), start = start.f, frequency = freq.x))
   }
-  else if (length(y) <= 1 | length(tt) <= 1) { # length(tt)==0 but length(y)>0. How does that happen?
+  else if (length(y) <= 1 || length(tt) <= 1) { # length(tt)==0 but length(y)>0. How does that happen?
     return(list(mean = ts(rep(NA, h), start = start.f, frequency = freq.x)))
   } else {
     y.f <- ses(y, alpha = alpha, initial = "simple", h = h, PI = FALSE)

--- a/R/forecastBATS.R
+++ b/R/forecastBATS.R
@@ -74,9 +74,9 @@ forecast.bats <- function(object, h, level=c(80, 95), fan=FALSE, biasadj=NULL, .
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }

--- a/R/forecastTBATS.R
+++ b/R/forecastTBATS.R
@@ -27,9 +27,9 @@ forecast.tbats <- function(object, h, level=c(80, 95), fan=FALSE, biasadj=NULL, 
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -118,7 +118,7 @@ autoplot.acf <- function(object, ci=0.95, ...) {
     }
 
     data <- data.frame(Lag = object$lag, ACF = object$acf)
-    if (data$Lag[1] == 0 & object$type == "correlation") {
+    if (data$Lag[1] == 0 && object$type == "correlation") {
       data <- data[-1, ]
     }
 
@@ -368,11 +368,11 @@ autoplot.Arima <- function(object, type = c("both", "ar", "ma"), ...) {
     # Prepare data
     arData <- maData <- NULL
     allRoots <- data.frame(roots = numeric(0), type = character(0))
-    if ("ar" %in% type & p > 0) {
+    if ("ar" %in% type && p > 0) {
       arData <- arroots(object)
       allRoots <- rbind(allRoots, data.frame(roots = arData$roots, type = arData$type))
     }
-    if ("ma" %in% type & q > 0) {
+    if ("ma" %in% type && q > 0) {
       maData <- maroots(object)
       allRoots <- rbind(allRoots, data.frame(roots = maData$roots, type = maData$type))
     }
@@ -584,7 +584,7 @@ autoplot.forecast <- function(object, include, PI=TRUE, shadecols=c("#596DD5", "
     if (!is.forecast(object)) {
       stop("autoplot.forecast requires a forecast object, use object=object")
     }
-    if (is.null(object$lower) | is.null(object$upper) | is.null(object$level)) {
+    if (is.null(object$lower) || is.null(object$upper) || is.null(object$level)) {
       PI <- FALSE
     }
     else if (!is.finite(max(object$upper))) {
@@ -1337,7 +1337,7 @@ ggseasonplot <- function(x, season.labels=NULL, year.labels=FALSE, year.labels.l
       yrlab <- rbind(yrlab, yrlabL)
     }
   }
-  if (year.labels | year.labels.left) {
+  if (year.labels || year.labels.left) {
     yrlab <- merge(yrlab, data)
     yrlab$time <- yrlab$time + yrlab$offset
     p <- p + ggplot2::guides(colour = FALSE)
@@ -1824,7 +1824,7 @@ autoplot.mts <- function(object, colour=TRUE, facets=FALSE, ...) {
 
     # Initialise ggplot object
     mapping <- ggplot2::aes_(y = ~y, x = ~x, group = ~series)
-    if (colour & (!facets | !missing(colour))) {
+    if (colour && (!facets || !missing(colour))) {
       mapping$colour <- quote(series)
     }
     p <- ggplot2::ggplot(mapping, data = data)
@@ -1888,7 +1888,7 @@ forecast2plotdf <- function(model, data=as.data.frame(model), PI=TRUE, showgap=T
   }
   Hiloc <- grep("Hi ", names(data))
   Loloc <- grep("Lo ", names(data))
-  if (PI & !is.null(model$level)) { # PI
+  if (PI && !is.null(model$level)) { # PI
     if (length(Hiloc) == length(Loloc)) {
       if (length(Hiloc) > 0) {
         out <- data.frame(
@@ -2304,7 +2304,7 @@ gghistogram <- function(x, add.normal=FALSE, add.kde=FALSE, add.rug=TRUE, bins, 
       ggplot2::geom_histogram(ggplot2::aes(x), data = data, binwidth = binwidth, boundary = boundary) +
       ggplot2::xlab(deparse(substitute(x)))
     # Add normal density estimate
-    if (add.normal | add.kde) {
+    if (add.normal || add.kde) {
       xmin <- min(x, na.rm = TRUE)
       xmax <- max(x, na.rm = TRUE)
       if (add.kde) {

--- a/R/lm.R
+++ b/R/lm.R
@@ -92,7 +92,7 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
   }
 
   ## Set column name of univariate dataset
-  if (is.null(dim(data)) & length(data) != 0) {
+  if (is.null(dim(data)) && length(data) != 0) {
     cn <- as.character(vars)[2]
   } else {
     cn <- colnames(data)
@@ -120,7 +120,7 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
     data <- cbind(data, trend)
   }
   if (tsdat[2] == 0) { # &tsvar[2]!=0){#If "season" is not in data, but is in formula
-    if (tsvar[2] != 0 & tspx[3] <= 1) { # Nonseasonal data, and season requested
+    if (tsvar[2] != 0 && tspx[3] <= 1) { # Nonseasonal data, and season requested
       stop("Non-seasonal data cannot be modelled using a seasonal factor")
     }
     season <- as.factor(cycle(data[, 1]))
@@ -141,7 +141,7 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
     warning("Subset has been assumed contiguous")
     timesx <- time(data[, 1])[subset]
     tspx <- recoverTSP(timesx)
-    if (tspx[3] == 1 & tsdat[2] == 0 & tsvar[2] != 0) {
+    if (tspx[3] == 1 && tsdat[2] == 0 && tsvar[2] != 0) {
       stop("Non-seasonal data cannot be modelled using a seasonal factor")
     }
     data <- data[subset, ] # model.frame(formula,as.data.frame(data[subsetTF,]))
@@ -149,7 +149,7 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
   if (!is.null(lambda)) {
     data[, 1] <- BoxCox(data[, 1], lambda)
   }
-  if (tsdat[2] == 0 & tsvar[2] != 0) {
+  if (tsdat[2] == 0 && tsvar[2] != 0) {
     data$season <- factor(data$season) # fix for lost factor information, may not be needed?
   }
 
@@ -238,9 +238,9 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -268,15 +268,15 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
   }
 
   # Check if the forecasts will be time series
-  if (ts & is.element("ts", class(origdata))) {
+  if (ts && is.element("ts", class(origdata))) {
     tspx <- tsp(origdata)
     timesx <- time(origdata)
   }
-  else if (ts & is.element("ts", class(origdata[, 1]))) {
+  else if (ts && is.element("ts", class(origdata[, 1]))) {
     tspx <- tsp(origdata[, 1])
     timesx <- time(origdata[, 1])
   }
-  else if (ts & is.element("ts", class(fitted(object)))) {
+  else if (ts && is.element("ts", class(fitted(object)))) {
     tspx <- tsp(fitted(object))
     timesx <- time(fitted(object))
   }
@@ -347,7 +347,7 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
             # Check for misnamed columns
             fsub <- grep(paste(make.names(subvars), collapse = "|"), newvars)
           }
-          if (all(fsub != 0) & length(fsub) == length(subvars)) {
+          if (all(fsub != 0) && length(fsub) == length(subvars)) {
             imat <- as.matrix(newdata[, fsub], ncol = length(fsub))
             colnames(imat) <- subvars
             tmpdata[[length(tmpdata) + 1]] <- imat
@@ -399,7 +399,7 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
     oldnewdata <- newdata
   }
   # If only one column, assume its name.
-  if (ncol(newdata) == 1 & colnames(newdata)[1] == "newdata") {
+  if (ncol(newdata) == 1 && colnames(newdata)[1] == "newdata") {
     colnames(newdata) <- as.character(formula(object$model))[3]
   }
 

--- a/R/mstl.R
+++ b/R/mstl.R
@@ -250,7 +250,7 @@ forecast.stl <- function(object, method=c("ets", "arima", "naive", "rwdrift"), e
                          lambda=NULL, biasadj=NULL, xreg=NULL, newxreg=NULL, allow.multiplicative.trend=FALSE, ...) {
   method <- match.arg(method)
   if (is.null(forecastfunction)) {
-    if (method != "arima" & (!is.null(xreg) | !is.null(newxreg))) {
+    if (method != "arima" && (!is.null(xreg) || !is.null(newxreg))) {
       stop("xreg and newxreg arguments can only be used with ARIMA models")
     }
     if (method == "ets") {
@@ -422,7 +422,7 @@ stlm <- function(y, s.window=13, robust=FALSE, method=c("ets", "arima"), modelfu
   }
   # Construct modelfunction if not passed as an argument
   else if (is.null(modelfunction)) {
-    if (method != "arima" & !is.null(xreg)) {
+    if (method != "arima" && !is.null(xreg)) {
       stop("xreg arguments can only be used with ARIMA models")
     }
     if (method == "ets") {
@@ -501,7 +501,7 @@ forecast.stlm <- function(object, h = 2 * object$m, level = c(80, 95), fan = FAL
   n <- NROW(xdata)
 
   # Forecast seasonally adjusted series
-  if (is.element("Arima", class(object$model)) & !is.null(newxreg)) {
+  if (is.element("Arima", class(object$model)) && !is.null(newxreg)) {
     fcast <- forecast(object$model, h = h, level = level, xreg = newxreg, ...)
   } else if (is.element("ets", class(object$model))) {
     fcast <- forecast(

--- a/R/msts.R
+++ b/R/msts.R
@@ -31,7 +31,7 @@ msts <- function(data, seasonal.periods, ts.frequency=floor(max(seasonal.periods
   # if(!is.element(ts.frequency, round(seasonal.periods-0.5+1e-12)))
   #  stop("ts.frequency should be one of the seasonal periods")
 
-  if (inherits(data, "ts") & frequency(data) == ts.frequency & length(list(...)) == 0) {
+  if (inherits(data, "ts") && frequency(data) == ts.frequency && length(list(...)) == 0) {
     object <- data
   } else {
     object <- ts(data = data, frequency = ts.frequency, ...)

--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -99,7 +99,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
                        allowdrift=TRUE, allowmean=TRUE, lambda=NULL, biasadj=FALSE,
                        parallel=FALSE, num.cores=2, x=y, ...) {
   # Only non-stepwise parallel implemented so far.
-  if (stepwise == TRUE & parallel == TRUE) {
+  if (stepwise && parallel) {
     warning("Parallel computer is only implemented when stepwise=FALSE, the model will be fit in serial.")
     parallel <- FALSE
   }
@@ -166,7 +166,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
     # Make sure it is a matrix with column names
     nmxreg <- deparse(substitute(xreg))
     xregg <- as.matrix(xreg)
-    if (ncol(xregg) == 1 & length(nmxreg) > 1) {
+    if (ncol(xregg) == 1 && length(nmxreg) > 1) {
       nmxreg <- "xreg"
     }
     if (is.null(colnames(xregg))) {
@@ -212,7 +212,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
   {
     D <- nsdiffs(xx, test=seasonal.test, max.D=max.D)
     # Make sure xreg is not null after differencing
-    if (D > 0 & !is.null(xregg)) {
+    if (D > 0 && !is.null(xregg)) {
       diffxreg <- diff(xregg, differences = D, lag = m)
       if (any(apply(diffxreg, 2, is.constant))) {
         D <- D - 1
@@ -234,7 +234,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
   if (is.na(d)) {
     d <- ndiffs(dx, test = test, max.d = max.d)
     # Make sure xreg is not null after differencing
-    if (d > 0 & !is.null(xregg)) {
+    if (d > 0 && !is.null(xregg)) {
       diffxreg <- diff(diffxreg, differences = d, lag = 1)
       if (any(apply(diffxreg, 2, is.constant))) {
         d <- d - 1
@@ -350,7 +350,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
 
   results <- matrix(NA, nrow = 100, ncol = 8)
 
-  if (approximation & trace) {
+  if (approximation && trace) {
     cat("\n Fitting models using approximations to speed things up...\n")
   }
 
@@ -364,7 +364,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
     p <- q <- P <- Q <- 0
   }
   # Basic AR model
-  if (max.p > 0 | max.P > 0) {
+  if (max.p > 0 || max.P > 0) {
     fit <- myarima(x, order = c(max.p > 0, d, 0), seasonal = c((m > 1) & (max.P > 0), D, 0), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
     results[3, ] <- c(1, d, 0, m > 1, D, 0, constant, fit$ic)
     if (fit$ic < bestfit$ic) {
@@ -375,7 +375,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
     }
   }
   # Basic MA model
-  if (max.q > 0 | max.Q > 0) {
+  if (max.q > 0 || max.Q > 0) {
     fit <- myarima(x, order = c(0, d, max.q > 0), seasonal = c(0, D, (m > 1) & (max.Q > 0)), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
     results[4, ] <- c(0, d, 1, 0, D, m > 1, constant, fit$ic)
     if (fit$ic < bestfit$ic) {
@@ -398,9 +398,9 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
   }
 
   startk <- 0
-  while (startk < k & k < 94) {
+  while (startk < k && k < 94) {
     startk <- k
-    if (P > 0 & newmodel(p, d, q, P - 1, D, Q, constant, results[1:k, ])) {
+    if (P > 0 && newmodel(p, d, q, P - 1, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P - 1, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P - 1, D, Q, constant, fit$ic)
@@ -409,7 +409,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         P <- (P - 1)
       }
     }
-    if (P < max.P & newmodel(p, d, q, P + 1, D, Q, constant, results[1:k, ])) {
+    if (P < max.P && newmodel(p, d, q, P + 1, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P + 1, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P + 1, D, Q, constant, fit$ic)
@@ -418,7 +418,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         P <- (P + 1)
       }
     }
-    if (Q > 0 & newmodel(p, d, q, P, D, Q - 1, constant, results[1:k, ])) {
+    if (Q > 0 && newmodel(p, d, q, P, D, Q - 1, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P, D, Q - 1), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P, D, Q - 1, constant, fit$ic)
@@ -427,7 +427,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         Q <- (Q - 1)
       }
     }
-    if (Q < max.Q & newmodel(p, d, q, P, D, Q + 1, constant, results[1:k, ])) {
+    if (Q < max.Q && newmodel(p, d, q, P, D, Q + 1, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P, D, Q + 1), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P, D, Q + 1, constant, fit$ic)
@@ -436,7 +436,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         Q <- (Q + 1)
       }
     }
-    if (Q > 0 & P > 0 & newmodel(p, d, q, P - 1, D, Q - 1, constant, results[1:k, ])) {
+    if (Q > 0 && P > 0 && newmodel(p, d, q, P - 1, D, Q - 1, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P - 1, D, Q - 1), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P - 1, D, Q - 1, constant, fit$ic)
@@ -446,7 +446,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         P <- (P - 1)
       }
     }
-    if (Q < max.Q & P < max.P & newmodel(p, d, q, P + 1, D, Q + 1, constant, results[1:k, ])) {
+    if (Q < max.Q && P < max.P && newmodel(p, d, q, P + 1, D, Q + 1, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q), seasonal = c(P + 1, D, Q + 1), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q, P + 1, D, Q + 1, constant, fit$ic)
@@ -457,7 +457,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
       }
     }
 
-    if (p > 0 & newmodel(p - 1, d, q, P, D, Q, constant, results[1:k, ])) {
+    if (p > 0 && newmodel(p - 1, d, q, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p - 1, d, q), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p - 1, d, q, P, D, Q, constant, fit$ic)
@@ -466,7 +466,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         p <- (p - 1)
       }
     }
-    if (p < max.p & newmodel(p + 1, d, q, P, D, Q, constant, results[1:k, ])) {
+    if (p < max.p && newmodel(p + 1, d, q, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p + 1, d, q), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p + 1, d, q, P, D, Q, constant, fit$ic)
@@ -475,7 +475,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         p <- (p + 1)
       }
     }
-    if (q > 0 & newmodel(p, d, q - 1, P, D, Q, constant, results[1:k, ])) {
+    if (q > 0 && newmodel(p, d, q - 1, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q - 1), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q - 1, P, D, Q, constant, fit$ic)
@@ -484,7 +484,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         q <- (q - 1)
       }
     }
-    if (q < max.q & newmodel(p, d, q + 1, P, D, Q, constant, results[1:k, ])) {
+    if (q < max.q && newmodel(p, d, q + 1, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p, d, q + 1), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p, d, q + 1, P, D, Q, constant, fit$ic)
@@ -493,7 +493,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         q <- (q + 1)
       }
     }
-    if (q > 0 & p > 0 & newmodel(p - 1, d, q - 1, P, D, Q, constant, results[1:k, ])) {
+    if (q > 0 && p > 0 && newmodel(p - 1, d, q - 1, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p - 1, d, q - 1), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p - 1, d, q - 1, P, D, Q, constant, fit$ic)
@@ -503,7 +503,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         p <- (p - 1)
       }
     }
-    if (q < max.q & p < max.p & newmodel(p + 1, d, q + 1, P, D, Q, constant, results[1:k, ])) {
+    if (q < max.q && p < max.p && newmodel(p + 1, d, q + 1, P, D, Q, constant, results[1:k, ])) {
       k <- k + 1
       fit <- myarima(x, order = c(p + 1, d, q + 1), seasonal = c(P, D, Q), constant = constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
       results[k, ] <- c(p + 1, d, q + 1, P, D, Q, constant, fit$ic)
@@ -513,7 +513,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         p <- (p + 1)
       }
     }
-    if (allowdrift | allowmean) {
+    if (allowdrift || allowmean) {
       if (newmodel(p, d, q, P, D, Q, !constant, results[1:k, ])) {
         k <- k + 1
         fit <- myarima(x, order = c(p, d, q), seasonal = c(P, D, Q), constant = !constant, ic, trace, approximation, offset = offset, xreg = xreg, ...)
@@ -527,7 +527,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
   }
 
   # Refit using ML if approximation used for IC
-  if (approximation & !is.null(bestfit$arma)) {
+  if (approximation && !is.null(bestfit$arma)) {
     if (trace) {
       cat("\n\n Now re-fitting the best model(s) without approximations...\n")
     }
@@ -588,7 +588,7 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
   } else {
     method <- "CSS-ML"
   }
-  if (diffs == 1 & constant) {
+  if (diffs == 1 && constant) {
     xreg <- cbind(drift = 1:length(x), xreg)
     if (use.season) {
       suppressWarnings(fit <- try(stats::arima(x = x, order = order, seasonal = list(order = seasonal, period = m), xreg = xreg, method = method, ...), silent = TRUE))
@@ -610,7 +610,7 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
   }
   if (!is.element("try-error", class(fit))) {
     nstar <- n - order[2] - seasonal[2] * m
-    if (diffs == 1 & constant) {
+    if (diffs == 1 && constant) {
       # fitnames <- names(fit$coef)
       # fitnames[length(fitnames)-nxreg] <- "drift"
       # names(fit$coef) <- fitnames
@@ -680,11 +680,11 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
       if (use.season) {
         cat("(", seasonal[1], ",", seasonal[2], ",", seasonal[3], ")[", m, "]", sep = "")
       }
-      if (constant & (order[2] + seasonal[2] == 0)) {
+      if (constant && (order[2] + seasonal[2] == 0)) {
         cat(" with non-zero mean")
-      } else if (constant & (order[2] + seasonal[2] == 1)) {
+      } else if (constant && (order[2] + seasonal[2] == 1)) {
         cat(" with drift        ")
-      } else if (!constant & (order[2] + seasonal[2] == 0)) {
+      } else if (!constant && (order[2] + seasonal[2] == 0)) {
         cat(" with zero mean    ")
       } else {
         cat("                   ")
@@ -710,10 +710,10 @@ arima.string <- function(object, padding=FALSE) {
   order <- object$arma[c(1, 6, 2, 3, 7, 4, 5)]
   m <- order[7]
   result <- paste("ARIMA(", order[1], ",", order[2], ",", order[3], ")", sep = "")
-  if (m > 1 & sum(order[4:6]) > 0) {
+  if (m > 1 && sum(order[4:6]) > 0) {
     result <- paste(result, "(", order[4], ",", order[5], ",", order[6], ")[", m, "]", sep = "")
   }
-  if (padding & m > 1 & sum(order[4:6]) == 0) {
+  if (padding && m > 1 && sum(order[4:6]) == 0) {
     result <- paste(result, "         ", sep = "")
     if (m <= 9) {
       result <- paste(result, " ", sep = "")
@@ -724,16 +724,16 @@ arima.string <- function(object, padding=FALSE) {
     }
   }
   if (!is.null(object$xreg)) {
-    if (NCOL(object$xreg) == 1 & is.element("drift", names(object$coef))) {
+    if (NCOL(object$xreg) == 1 && is.element("drift", names(object$coef))) {
       result <- paste(result, "with drift        ")
     } else {
       result <- paste("Regression with", result, "errors")
     }
   }
   else {
-    if (is.element("constant", names(object$coef)) | is.element("intercept", names(object$coef))) {
+    if (is.element("constant", names(object$coef)) || is.element("intercept", names(object$coef))) {
       result <- paste(result, "with non-zero mean")
-    } else if (order[2] == 0 & order[5] == 0) {
+    } else if (order[2] == 0 && order[5] == 0) {
       result <- paste(result, "with zero mean    ")
     } else {
       result <- paste(result, "                  ")

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -149,7 +149,7 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   }
 
   # Transform data
-  if (!is.null(lambda) & !constant_data) {
+  if (!is.null(lambda) && !constant_data) {
     xx <- BoxCox(x, lambda)
   } else {
     xx <- x
@@ -164,7 +164,7 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   }
   # Scale series
   scalex <- NULL
-  if (scale.inputs & !constant_data) {
+  if (scale.inputs && !constant_data) {
     if (useoldmodel) {
       scalex <- model$scalex
     }
@@ -239,7 +239,7 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
       warning("Reducing number of lagged inputs due to short series")
       p <- n - 2
     }
-    if (P > 0 & n >= m * P + 2) {
+    if (P > 0 && n >= m * P + 2) {
       lags <- sort(unique(c(1:p, m * (1:P))))
     } else {
       lags <- 1:p
@@ -421,9 +421,9 @@ forecast.nnetar <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -148,7 +148,7 @@ residuals.fracdiff <- function(object, type=c("innovation", "response"), ...) {
 #' @export
 residuals.nnetar <- function(object, type=c("innovation", "response"), h=1, ...) {
   type <- match.arg(type)
-  if (type == "innovation" & !is.null(object$lambda)) {
+  if (type == "innovation" && !is.null(object$lambda)) {
     res <- matrix(unlist(lapply(object$model, residuals)), ncol = length(object$model))
     if (!is.null(object$scalex$scale)) {
       res <- res * object$scalex$scale

--- a/R/season.R
+++ b/R/season.R
@@ -350,7 +350,7 @@ ma <- function(x, order, centre=TRUE) {
     stop("order must be an integer")
   }
 
-  if (order %% 2 == 0 & centre) { # centred and even
+  if (order %% 2 == 0 && centre) { # centred and even
     w <- c(0.5, rep(1, order - 1), 0.5) / order
   } else { # odd or not centred
     w <- rep(1, order) / order

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -178,7 +178,7 @@ myarima.sim <- function(model, n, x, e, ...) {
   ## AR "filtering"
   len.ar <- length(model$ar)
 
-  if (length(model$ar) & (len.ar <= length(data))) {
+  if (length(model$ar) && (len.ar <= length(data))) {
     if ((D != 0) && (d != 0)) {
       diff.data <- diff(data, lag = 1, differences = d)
       diff.data <- diff(diff.data, lag = m, differences = D)
@@ -221,7 +221,7 @@ myarima.sim <- function(model, n, x, e, ...) {
       xdiff <- model$x - x[1:n.start]
     }
     # If all same sign, choose last
-    if (all(sign(xdiff) == 1) | all(sign(xdiff) == -1)) {
+    if (all(sign(xdiff) == 1) || all(sign(xdiff) == -1)) {
       xdiff <- xdiff[length(xdiff)]
     } else { # choose mean.
       xdiff <- mean(xdiff)
@@ -452,7 +452,7 @@ simulate.Arima <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL, 
     }
     tsp(sim) <- tsp(x)
     # If model is non-stationary, then condition simulated data on first observation
-    if (model$order[2] > 0 | flag.seasonal.diff) {
+    if (model$order[2] > 0 || flag.seasonal.diff) {
       sim <- sim - sim[1] + x[1]
     }
   }

--- a/R/spline.R
+++ b/R/spline.R
@@ -172,9 +172,9 @@ splinef <- function(y, h=10, level=c(80, 95), fan=FALSE, lambda=NULL, biasadj=FA
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }

--- a/R/tbats.R
+++ b/R/tbats.R
@@ -382,11 +382,11 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
     best.model <- non.seasonal.model
   }
 
-  if ((length(use.box.cox) == 1) & (use.trend[1] == TRUE) & (length(use.trend) == 1) & (length(use.damped.trend) == 1) & (use.parallel)) {
+  if ((length(use.box.cox) == 1) && use.trend[1] && (length(use.trend) == 1) && (length(use.damped.trend) == 1) && (use.parallel)) {
     # In the this case, there is only one alternative.
     use.parallel <- FALSE
     stopCluster(clus)
-  } else if ((length(use.box.cox) == 1) & (use.trend[1] == FALSE) & (length(use.trend) == 1) & (use.parallel)) {
+  } else if ((length(use.box.cox) == 1) && !use.trend[1] && (length(use.trend) == 1) && (use.parallel)) {
     # As above, in the this case, there is only one alternative.
     use.parallel <- FALSE
     stopCluster(clus)
@@ -398,7 +398,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
     for (box.cox in use.box.cox) {
       for (trend in use.trend) {
         for (damping in use.damped.trend) {
-          if ((trend == FALSE) & (damping == TRUE)) {
+          if (!trend && damping) {
             next
           }
           control.line <- c(box.cox, trend, damping)
@@ -429,7 +429,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
         for (damping in use.damped.trend) {
           if (all((model.params == c(box.cox, trend, damping)))) {
             new.model <- filterTBATSSpecifics(y, box.cox, trend, damping, seasonal.periods, k.vector, use.arma.errors, aux.model = aux.model, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj, ...)
-          } else if (!((trend == FALSE) & (damping == TRUE))) {
+          } else if (trend || !damping) {
             new.model <- filterTBATSSpecifics(y, box.cox, trend, damping, seasonal.periods, k.vector, use.arma.errors, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj, ...)
           }
           if (new.model$AIC < best.model$AIC) {
@@ -471,7 +471,7 @@ parFilterTBATSSpecifics <- function(control.number, y, control.array, model.para
     if (!is.element("try-error", class(arma))) {
       p <- arma$arma[1]
       q <- arma$arma[2]
-      if ((p != 0) | (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
+      if ((p != 0) || (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
         if (p != 0) {
           ar.coefs <- numeric(p)
         } else {
@@ -539,7 +539,7 @@ filterTBATSSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, k
     if (!is.element("try-error", class(arma))) {
       p <- arma$arma[1]
       q <- arma$arma[2]
-      if ((p != 0) | (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
+      if ((p != 0) || (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
         if (p != 0) {
           ar.coefs <- numeric(p)
         } else {

--- a/R/theta.R
+++ b/R/theta.R
@@ -70,9 +70,9 @@ thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   if (fan) {
     level <- seq(51, 99, by = 3)
   } else {
-    if (min(level) > 0 & max(level) < 1) {
+    if (min(level) > 0 && max(level) < 1) {
       level <- 100 * level
-    } else if (min(level) < 0 | max(level) > 99.99) {
+    } else if (min(level) < 0 || max(level) > 99.99) {
       stop("Confidence limit out of range")
     }
   }
@@ -81,7 +81,7 @@ thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   n <- length(x)
   x <- as.ts(x)
   m <- frequency(x)
-  if (m > 1 & !is.constant(x)) {
+  if (m > 1 && !is.constant(x)) {
     r <- as.numeric(acf(x, lag.max = m, plot = FALSE)$acf)[-1]
     stat <- sqrt((1 + 2 * sum(r[-m] ^ 2)) / n)
     seasonal <- (abs(r[m]) / stat > qnorm(0.95))

--- a/R/unitRoot.R
+++ b/R/unitRoot.R
@@ -82,7 +82,7 @@ ndiffs <- function(x,alpha=0.05,test=c("kpss","adf","pp"), type=c("level", "tren
   {
     return(d)
   }
-  while(dodiff & d < max.d)
+  while(dodiff && d < max.d)
   {
     d <- d+1
     x <- diff(x)
@@ -156,7 +156,7 @@ nsdiffs <- function(x, alpha = 0.05, m=frequency(x), test=c("ocsb", "hegy", "ch"
     warning("Specified alpha value is larger than the maximum, setting alpha=0.1")
     alpha <- 0.1
   }
-  if(test == "ocsb" & alpha != 0.05){
+  if(test == "ocsb" && alpha != 0.05){
     warning("Significance levels other than 5% are not currently supported by test='ocsb', defaulting to alpha = 0.05.")
     alpha <- 0.05
   }
@@ -198,7 +198,7 @@ nsdiffs <- function(x, alpha = 0.05, m=frequency(x), test=c("ocsb", "hegy", "ch"
   
   dodiff <- runTests(x, test, alpha)
   
-  while(dodiff==1 & D < max.D)
+  while(dodiff==1 && D < max.D)
   {
     D <- D + 1
     x <- diff(x, lag=m)


### PR DESCRIPTION
Throughout forecast, `&` and `|` are used when `&&` and `||` would be more appropriate. I've changed some lines where such a change is uncontroversial, *viz.* statements within `if` and `while`. 

Though these forms typically have better performance because of their short-circuiting, not all cases will experience much of a performance increase. Nonetheless, I noticed a few within (nested) loops that probably will. 