### PR TITLE
simulate.nnetar check before scaling innovations

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -34,7 +34,7 @@
 #' \code{NULL}.
 #' @param ... Other arguments, not currently used.
 #' @inheritParams forecast
-#' 
+#'
 #' @return An object of class "\code{ts}".
 #' @author Rob J Hyndman
 #' @seealso \code{\link{ets}}, \code{\link{Arima}}, \code{\link{auto.arima}},
@@ -582,7 +582,10 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
     e <- rnorm(nsim, 0, sd(res, na.rm = TRUE))
   }
   else if (length(innov) == nsim) {
-    e <- innov / object$scalex$scale
+    e <- innov
+    if (!is.null(object$scalex$scale)){
+      e <- e/object$scalex$scale
+    }
   } else if (length(innov) == 1) {
     ## to pass innov=0 so simulation equals mean forecast
     e <- rep(innov, nsim) / object$scalex$scale

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -586,9 +586,9 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
     if (!is.null(object$scalex$scale)){
       e <- e/object$scalex$scale
     }
-  } else if (length(innov) == 1) {
+  } else if (isTRUE(innov == 0L)) {
     ## to pass innov=0 so simulation equals mean forecast
-    e <- rep(innov, nsim) / object$scalex$scale
+    e <- rep(innov, nsim)
   } else {
     stop("Length of innov must be equal to nsim")
   }


### PR DESCRIPTION
I noticed that `innov` in `simulate.nnetar` was always scaled. I added a check to make sure the inputs were actually scaled in the original model, otherwise `object$scalex$scale` would be `NULL`. I also modified slightly the code checking for `innov = 0` to make it both clearer and also to avoid unintended problems (say if `innov` equals some other scalar value).