### PR TITLE
Short and constant data in nnetar

### DIFF
--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -272,6 +272,10 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   j <- complete.cases(lags.X, y)
   ## Remove values not in subset
   j <- j & xsub[-(1:maxlag)]
+  ## Stop if there's no data to fit (e.g. due to NAs or NaNs)
+  if (NROW(lags.X[j,, drop=FALSE]) == 0) {
+    stop("No data to fit (possibly due to NA or NaN)")
+  }
   ## Fit average ANN.
   if (useoldmodel) {
     fit <- oldmodel_avnnet(lags.X[j, , drop = FALSE], y[j], size = size, model)

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -140,9 +140,11 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
     # Check for constant data
     constant_data <- is.constant(na.interp(x))
     if (constant_data){
+      warning("Constant data, setting p=1, P=0, lambda=NULL, scale.inputs=FALSE")
       scale.inputs <- FALSE
       lambda <- NULL
       p <- 1
+      P <- 0
     }
   }
   # Check for NAs in x

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -108,7 +108,7 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
     }
     # Check new data
     m <- max(round(frequency(model$x)), 1L)
-    minlength <- max(c(model$p, model$P * m))
+    minlength <- max(c(model$p, model$P * m)) + 1
     if (length(x) < minlength) {
       stop(paste("Series must be at least of length", minlength, "to use fitted model"))
     }
@@ -130,6 +130,11 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
     size <- model$size
     p <- model$p
     P <- model$P
+    if (P > 0) {
+      lags <- sort(unique(c(1:p, m * (1:P))))
+    } else {
+      lags <- 1:p
+    }
     if (is.null(model$scalex)) {
       scale.inputs <- FALSE
     }

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -138,11 +138,11 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
     if (is.null(model$scalex)) {
       scale.inputs <- FALSE
     }
-  } else {                 # when not using and old model
+  } else {                 # when not using an old model
     if (length(y) < 3) {
       stop("Not enough data to fit a model")
     }
-    # Check for constant data
+    # Check for constant data in time series
     constant_data <- is.constant(na.interp(x))
     if (constant_data){
       warning("Constant data, setting p=1, P=0, lambda=NULL, scale.inputs=FALSE")
@@ -151,7 +151,16 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
       p <- 1
       P <- 0
     }
+    ## Check for constant data in xreg
+    if (!is.null(xreg)){
+      constant_xreg <- any(apply(as.matrix(xreg), 2, function(x) is.constant(na.interp(x))))
+      if (constant_xreg){
+        warning("Constant xreg column, setting scale.inputs=FALSE")
+        scale.inputs <- FALSE
+      }
+    }
   }
+
   # Check for NAs in x
   if (any(is.na(x))) {
     warning("Missing values in x, omitting rows")

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -57,7 +57,7 @@
 #' @param \dots Other arguments passed to \code{\link[nnet]{nnet}} for
 #' \code{nnetar}.
 #' @inheritParams forecast
-#' 
+#'
 #' @return Returns an object of class "\code{nnetar}".
 #'
 #' The function \code{summary} is used to obtain and print a summary of the
@@ -218,9 +218,9 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
     if (missing(p)) {
       p <- max(length(ar(na.interp(xx))$ar), 1)
     }
-    if (p >= n - 1) {
+    if (p >= n) {
       warning("Reducing number of lagged inputs due to short series")
-      p <- n - 2
+      p <- n - 1
     }
     lags <- 1:p
     if (P > 1) {
@@ -237,9 +237,9 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
       }
       p <- max(length(ar(x.sa)$ar), 1)
     }
-    if (p >= n - 1) {
+    if (p >= n) {
       warning("Reducing number of lagged inputs due to short series")
-      p <- n - 2
+      p <- n - 1
     }
     if (P > 0 && n >= m * P + 2) {
       lags <- sort(unique(c(1:p, m * (1:P))))
@@ -268,9 +268,9 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   j <- j & xsub[-(1:maxlag)]
   ## Fit average ANN.
   if (useoldmodel) {
-    fit <- oldmodel_avnnet(lags.X[j, ], y[j], size = size, model)
+    fit <- oldmodel_avnnet(lags.X[j, , drop = FALSE], y[j], size = size, model)
   } else {
-    fit <- avnnet(lags.X[j, ], y[j], size = size, repeats = repeats, ...)
+    fit <- avnnet(lags.X[j, , drop=FALSE], y[j], size = size, repeats = repeats, ...)
   }
   # Return results
   out <- list()
@@ -289,7 +289,11 @@ nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NU
   if (useoldmodel) {
     out$nnetargs <- model$nnetargs
   }
-  fits <- c(rep(NA_real_, maxlag), rowMeans(sapply(fit, predict)))
+  if (NROW(lags.X[j,, drop=FALSE]) == 1){
+    fits <- c(rep(NA_real_, maxlag), mean(sapply(fit, predict)))
+  } else{
+    fits <- c(rep(NA_real_, maxlag), rowMeans(sapply(fit, predict)))
+  }
   if (scale.inputs) {
     fits <- fits * scalex$scale + scalex$center
   }
@@ -381,7 +385,7 @@ print.nnetarmodels <- function(x, ...) {
 #' into a matrix). If present, \code{bootstrap} is ignored.
 #' @param ... Additional arguments passed to \code{\link{simulate.nnetar}}
 #' @inheritParams forecast
-#' 
+#'
 #' @return An object of class "\code{forecast}".
 #'
 #' The function \code{summary} is used to obtain and print a summary of the

--- a/tests/testthat/test-nnetar.R
+++ b/tests/testthat/test-nnetar.R
@@ -112,6 +112,7 @@ if (require(testthat)) {
     expect_warning(nnetfit <- nnetar(rep(1, 10), p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant data")
     expect_true(nnetfit$p == 1)
     expect_true(is.null(nnetfit$lambda))
+    expect_true(is.null(nnetfit$scalex))
     expect_error(nnetfit <- nnetar(rnorm(2), p=1, P=0, size=1, repeats=1), "Not enough data")
     expect_silent(nnetfit <- nnetar(rnorm(3), p=1, P=0, size=1, repeats=1))
     expect_true(nnetfit$p == 1)
@@ -121,5 +122,9 @@ if (require(testthat)) {
     expect_true(nnetfit$p == 2)
     expect_warning(nnetfit <- nnetar(rnorm(3), p=4, P=0, size=1, repeats=1), "short series")
     expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- nnetar(rnorm(10), xreg=rep(1, 10), p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_true(is.null(nnetfit$scalexreg))
+    expect_warning(nnetfit <- nnetar(rnorm(3), xreg=matrix(c(1, 2, 3, 1, 1, 1), ncol=2), p=1, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_true(is.null(nnetfit$scalexreg))
   })
 }

--- a/tests/testthat/test-nnetar.R
+++ b/tests/testthat/test-nnetar.R
@@ -108,5 +108,18 @@ if (require(testthat)) {
     expect_true(identical(which(!is.na(fitted(oilnnet))), 11:20))
     oilnnet <- nnetar(airmiles, subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)))
     expect_true(identical(which(!is.na(fitted(oilnnet))), 11:20))
+    ## Check short and constant data
+    expect_warning(nnetfit <- nnetar(rep(1, 10), p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant data")
+    expect_true(nnetfit$p == 1)
+    expect_true(is.null(nnetfit$lambda))
+    expect_error(nnetfit <- nnetar(rnorm(2), p=1, P=0, size=1, repeats=1), "Not enough data")
+    expect_silent(nnetfit <- nnetar(rnorm(3), p=1, P=0, size=1, repeats=1))
+    expect_true(nnetfit$p == 1)
+    expect_silent(nnetfit <- nnetar(rnorm(3), p=2, P=0, size=1, repeats=1))
+    expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- nnetar(rnorm(3), p=3, P=0, size=1, repeats=1), "short series")
+    expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- nnetar(rnorm(3), p=4, P=0, size=1, repeats=1), "short series")
+    expect_true(nnetfit$p == 2)
   })
 }


### PR DESCRIPTION
The checks and modification of some parameters like `p` and `lambda` for short or constant data was sometimes being applied when old models were used rather than just new fits. This could lead to unexpected results. I made some changes so those checks were only done if the `model` argument wasn't being used, plus a couple additional tweaks. 

- Adding [`drop = FALSE`](https://github.com/robjhyndman/forecast/compare/robjhyndman:9ea51c8...gabrielcaceres:26eee20#diff-2598d576ddd8340cb32138c059517b22R277) allows the model to be fit with a single observation after accounting for the lags (by keeping `lags.X` as a matrix instead of coercing it into a vector which gave an error). I assume the prior error was the reason [for checking for `n-1`](https://github.com/robjhyndman/forecast/blob/9ea51c8897e384ea523b0f43ee9485fe91743ccc/R/nnetar.R#L221-L224) rather than `n`? I [changed](https://github.com/robjhyndman/forecast/compare/robjhyndman:9ea51c8...gabrielcaceres:26eee20#diff-2598d576ddd8340cb32138c059517b22R227) said check accordingly.

- The [diff](https://github.com/robjhyndman/forecast/compare/robjhyndman:9ea51c8...gabrielcaceres:26eee20#diff-2598d576ddd8340cb32138c059517b22L217) around the [`if (m==1) {...}{else{...}` block](https://github.com/robjhyndman/forecast/blob/9ea51c8897e384ea523b0f43ee9485fe91743ccc/R/nnetar.R#L217-L253) looks complicated, but all I did (in addition to the previous bullet) was wrap it in another `if` checking whether `useoldmodel` is set.

- I moved the [check](https://github.com/robjhyndman/forecast/blob/9ea51c8897e384ea523b0f43ee9485fe91743ccc/R/nnetar.R#L214-L216) for constant data [inside](https://github.com/robjhyndman/forecast/compare/robjhyndman:9ea51c8...gabrielcaceres:26eee20#diff-2598d576ddd8340cb32138c059517b22R147) the `if` for `useoldmodel`, and changed all parameters in there at once (and included a warning).

- I added some unit tests for the errors and warning when using short/constant data.