### PR TITLE
Pretty print arimaorder()

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -895,6 +895,7 @@ print.ARIMA <- function(x, digits=max(3, getOption("digits") - 3), se=TRUE, ...)
 arimaorder <- function(object) {
   if (is.element("Arima", class(object))) {
     order <- object$arma[c(1, 6, 2, 3, 7, 4, 5)]
+    names(order) <- c("p", "d", "q", "P", "D", "Q", "Frequency")
     seasonal <- (order[7] > 1 & sum(order[4:6]) > 0)
     if (seasonal) {
       return(order)
@@ -903,10 +904,10 @@ arimaorder <- function(object) {
     }
   }
   else if (is.element("ar", class(object))) {
-    return(c(object$order, 0, 0))
+    return(c("p" = object$order, "d" = 0, "q" = 0))
   }
   else if (is.element("fracdiff", class(object))) {
-    return(c(length(object$ar), object$d, length(object$ma)))
+    return(c("p" = length(object$ar), "d" = object$d, "q" = length(object$ma)))
   }
   else {
     stop("object not of class Arima, ar or fracdiff")

--- a/tests/testthat/test-arima.R
+++ b/tests/testthat/test-arima.R
@@ -27,9 +27,20 @@ if (require(testthat)) {
           iextracted <- fitarima$arma[6]
           maextracted <- fitarima$arma[2]
           expect_true(all(arimaorder(fitarima) == c(arextracted, iextracted, maextracted)))
+          expect_true(all(names(arimaorder(fitarima)) %in% c("p", "d", "q")))
+          expect_true(arimaorder(fitarima)["p"] == ar)
+          expect_true(arimaorder(fitarima)["d"] == i)
+          expect_true(arimaorder(fitarima)["q"] == ma)
         }
       }
     }
+
+    # Test ar
+    arMod <- ar(lynx, order.max = 2)
+    expect_true(arimaorder(arMod)["p"] == 2)
+    expect_true(arimaorder(arMod)["d"] == 0)
+    expect_true(arimaorder(arMod)["q"] == 0)
+    expect_true(all(names(arimaorder(arMod)) == c("p", "d", "q"))
   })
 
   test_that("tests for forecast.Arima", {

--- a/tests/testthat/test-arima.R
+++ b/tests/testthat/test-arima.R
@@ -52,6 +52,15 @@ if (require(testthat)) {
     expect_true(arimaorder(sarimaMod)["D"] == 1)
     expect_true(arimaorder(sarimaMod)["Q"] == 1)
     expect_true(arimaorder(sarimaMod)["Frequency"] == frequency(wineind))
+
+    # Test fracdiff
+    set.seed(4)
+    fracdiffMod <- fracdiff::fracdiff(lynx, nar = 2, nma = 2)
+    expect_true(all(names(arimaorder(fracdiffMod)) == c("p", "d", "q")))
+    expect_true(arimaorder(fracdiffMod)["p"] == 2)
+    expect_true(arimaorder(fracdiffMod)["d"] >= 0)
+    expect_true(arimaorder(fracdiffMod)["d"] <= 1)
+    expect_true(arimaorder(fracdiffMod)["p"] == 2)
   })
 
   test_that("tests for forecast.Arima", {

--- a/tests/testthat/test-arima.R
+++ b/tests/testthat/test-arima.R
@@ -27,7 +27,7 @@ if (require(testthat)) {
           iextracted <- fitarima$arma[6]
           maextracted <- fitarima$arma[2]
           expect_true(all(arimaorder(fitarima) == c(arextracted, iextracted, maextracted)))
-          expect_true(all(names(arimaorder(fitarima)) %in% c("p", "d", "q")))
+          expect_true(all(names(arimaorder(fitarima)) == c("p", "d", "q")))
           expect_true(arimaorder(fitarima)["p"] == ar)
           expect_true(arimaorder(fitarima)["d"] == i)
           expect_true(arimaorder(fitarima)["q"] == ma)
@@ -40,7 +40,18 @@ if (require(testthat)) {
     expect_true(arimaorder(arMod)["p"] == 2)
     expect_true(arimaorder(arMod)["d"] == 0)
     expect_true(arimaorder(arMod)["q"] == 0)
-    expect_true(all(names(arimaorder(arMod)) == c("p", "d", "q"))
+    expect_true(all(names(arimaorder(arMod)) == c("p", "d", "q")))
+
+    # Test SARIMA
+    sarimaMod <- Arima(wineind, order = c(1, 1, 2), seasonal=c(0, 1,1))
+    expect_true(all(names(arimaorder(sarimaMod)) == c("p", "d", "q", "P", "D", "Q", "Frequency")))
+    expect_true(arimaorder(sarimaMod)["p"] == 1)
+    expect_true(arimaorder(sarimaMod)["d"] == 1)
+    expect_true(arimaorder(sarimaMod)["q"] == 2)
+    expect_true(arimaorder(sarimaMod)["P"] == 0)
+    expect_true(arimaorder(sarimaMod)["D"] == 1)
+    expect_true(arimaorder(sarimaMod)["Q"] == 1)
+    expect_true(arimaorder(sarimaMod)["Frequency"] == frequency(wineind))
   })
 
   test_that("tests for forecast.Arima", {


### PR DESCRIPTION
This makes the output of `arimaorder()` more human readable, and now users can select the model order using name-based instead of only position-based indexing.
```
> mod <- auto.arima(wineind)
> arimaorder(mod)
        p         d         q         P         D         Q Frequency 
        1         1         2         0         1         1        12 
> arimaorder(mod)["P"]
P 
0 
> arimaorder(mod)[4]
P 
0 
```