### PR TITLE
Generalizing nnetar to user-defined functions

### DIFF
--- a/R/modelAR.R
+++ b/R/modelAR.R
@@ -6,6 +6,7 @@
 # if xreg is included then size = (p+P+ncol(xreg)+1)/2
 
 
+
 #' Neural Network Time Series Forecasts
 #'
 #' Feed-forward neural networks with a single hidden layer and lagged inputs
@@ -513,20 +514,19 @@ forecast.nnetar <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI
 
 #' @rdname fitted.Arima
 #' @export
-fitted.nnetar <- function(object, h=1, ...) {
+fitted.modelAR <- function(object, h=1, ...) {
   if (h == 1) {
     return(object$fitted)
   }
   else {
-    return(hfitted(object = object, h = h, FUN = "nnetar", ...))
+    return(hfitted(object = object, h = h, FUN = "modelAR", ...))
   }
 }
 
 #' @export
-print.nnetar <- function(x, digits = max(3, getOption("digits") - 3), ...) {
+print.modelAR <- function(x, digits = max(3, getOption("digits") - 3), ...) {
   cat("Series:", x$series, "\n")
   cat("Model: ", x$method, "\n")
-  # cat("  one hidden layer with",x$size,"nodes\n")
   cat("Call:   ")
   print(x$call)
   print(x$model)
@@ -539,6 +539,6 @@ print.nnetar <- function(x, digits = max(3, getOption("digits") - 3), ...) {
 
 #' @rdname is.ets
 #' @export
-is.nnetar <- function(x) {
-  inherits(x, "nnetar")
+is.modelAR <- function(x) {
+  inherits(x, "modelAR")
 }

--- a/R/modelAR.R
+++ b/R/modelAR.R
@@ -94,7 +94,7 @@
 #' fit2 <- nnetar(window(lynx,start=1921), model=fit)
 #'
 #' @export
-modelAR <- function(y, p, P=1, FUN, predict.FUN, xreg=NULL, lambda=NULL, model=NULL, subset=NULL, scale.inputs=TRUE, x=y, ...) {
+modelAR <- function(y, p, P=1, FUN, predict.FUN, xreg=NULL, lambda=NULL, model=NULL, subset=NULL, scale.inputs=FALSE, x=y, ...) {
   useoldmodel <- FALSE
   yname <- deparse(substitute(y))
   if (!is.null(model)) {
@@ -399,8 +399,7 @@ modelAR <- function(y, p, P=1, FUN, predict.FUN, xreg=NULL, lambda=NULL, model=N
 #' plot(fcast)
 #'
 #' @export
-forecast.nnetar <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI=FALSE, level=c(80, 95), fan=FALSE, xreg=NULL, lambda=object$lambda, bootstrap=FALSE, npaths=1000, innov=NULL, ...) {
-  #  require(nnet)
+forecast.modelAR <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI=FALSE, level=c(80, 95), fan=FALSE, xreg=NULL, lambda=object$lambda, bootstrap=FALSE, npaths=1000, innov=NULL, ...) {
   out <- object
   tspx <- tsp(out$x)
   #
@@ -456,7 +455,7 @@ forecast.nnetar <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI
     if (any(is.na(newdata))) {
       stop("I can't forecast when there are missing values near the end of the series.")
     }
-    fcast[i] <- mean(sapply(object$model, predict, newdata = newdata))
+    fcast[i] <- object$predict.FUN(object$model, newdata)
     flag <- c(fcast[i], flag[-maxlag])
   }
   # Re-scale point forecasts

--- a/R/modelAR.R
+++ b/R/modelAR.R
@@ -1,0 +1,544 @@
+# Defaults:
+# For non-seasonal data, p chosen using AIC from linear AR(p) model
+# For seasonal data, p chosen using AIC from linear AR(p) model after
+#    seasonally adjusting with STL decomposition, and P=1
+# size set to average of number of inputs and number of outputs: (p+P+1)/2
+# if xreg is included then size = (p+P+ncol(xreg)+1)/2
+
+
+#' Neural Network Time Series Forecasts
+#'
+#' Feed-forward neural networks with a single hidden layer and lagged inputs
+#' for forecasting univariate time series.
+#'
+#' A feed-forward neural network is fitted with lagged values of \code{y} as
+#' inputs and a single hidden layer with \code{size} nodes. The inputs are for
+#' lags 1 to \code{p}, and lags \code{m} to \code{mP} where
+#' \code{m=frequency(y)}. If \code{xreg} is provided, its columns are also
+#' used as inputs. If there are missing values in \code{y} or
+#' \code{xreg}, the corresponding rows (and any others which depend on them as
+#' lags) are omitted from the fit. A total of \code{repeats} networks are
+#' fitted, each with random starting weights. These are then averaged when
+#' computing forecasts. The network is trained for one-step forecasting.
+#' Multi-step forecasts are computed recursively.
+#'
+#' For non-seasonal data, the fitted model is denoted as an NNAR(p,k) model,
+#' where k is the number of hidden nodes. This is analogous to an AR(p) model
+#' but with nonlinear functions. For seasonal data, the fitted model is called
+#' an NNAR(p,P,k)[m] model, which is analogous to an ARIMA(p,0,0)(P,0,0)[m]
+#' model but with nonlinear functions.
+#'
+#' @aliases print.nnetar print.nnetarmodels
+#'
+#' @param y A numeric vector or time series of class \code{ts}.
+#' @param p Embedding dimension for non-seasonal time series. Number of
+#' non-seasonal lags used as inputs. For non-seasonal time series, the default
+#' is the optimal number of lags (according to the AIC) for a linear AR(p)
+#' model. For seasonal time series, the same method is used but applied to
+#' seasonally adjusted data (from an stl decomposition).
+#' @param P Number of seasonal lags used as inputs.
+#' @param size Number of nodes in the hidden layer. Default is half of the
+#' number of input nodes (including external regressors, if given) plus 1.
+#' @param repeats Number of networks to fit with different random starting
+#' weights. These are then averaged when producing forecasts.
+#' @param xreg Optionally, a vector or matrix of external regressors, which
+#' must have the same number of rows as \code{y}. Must be numeric.
+#' @param model Output from a previous call to \code{nnetar}. If model is
+#' passed, this same model is fitted to \code{y} without re-estimating any
+#' parameters.
+#' @param subset Optional vector specifying a subset of observations to be used
+#' in the fit. Can be an integer index vector or a logical vector the same
+#' length as \code{y}. All observations are used by default.
+#' @param scale.inputs If TRUE, inputs are scaled by subtracting the column
+#' means and dividing by their respective standard deviations. If \code{lambda}
+#' is not \code{NULL}, scaling is applied after Box-Cox transformation.
+#' @param x Deprecated. Included for backwards compatibility.
+#' @param \dots Other arguments passed to \code{\link[nnet]{nnet}} for
+#' \code{nnetar}.
+#' @inheritParams forecast
+#'
+#' @return Returns an object of class "\code{nnetar}".
+#'
+#' The function \code{summary} is used to obtain and print a summary of the
+#' results.
+#'
+#' The generic accessor functions \code{fitted.values} and \code{residuals}
+#' extract useful features of the value returned by \code{nnetar}.
+#'
+#' \item{model}{A list containing information about the fitted model}
+#' \item{method}{The name of the forecasting method as a character string}
+#' \item{x}{The original time series.}
+#' \item{xreg}{The external regressors used in fitting (if given).}
+#' \item{residuals}{Residuals from the fitted model. That is x minus fitted values.}
+#' \item{fitted}{Fitted values (one-step forecasts)}
+#' \item{...}{Other arguments}
+#'
+#' @author Rob J Hyndman and Gabriel Caceres
+#' @keywords ts
+#' @examples
+#' fit <- nnetar(lynx)
+#' fcast <- forecast(fit)
+#' plot(fcast)
+#'
+#' ## Arguments can be passed to nnet()
+#' fit <- nnetar(lynx, decay=0.5, maxit=150)
+#' plot(forecast(fit))
+#' lines(lynx)
+#'
+#' ## Fit model to first 100 years of lynx data
+#' fit <- nnetar(window(lynx,end=1920), decay=0.5, maxit=150)
+#' plot(forecast(fit,h=14))
+#' lines(lynx)
+#'
+#' ## Apply fitted model to later data, including all optional arguments
+#' fit2 <- nnetar(window(lynx,start=1921), model=fit)
+#'
+#' @export
+nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NULL, subset=NULL, scale.inputs=TRUE, x=y, ...) {
+  useoldmodel <- FALSE
+  yname <- deparse(substitute(y))
+  if (!is.null(model)) {
+    # Use previously fitted model
+    useoldmodel <- TRUE
+    # Check for conflicts between new and old data:
+    # Check model class
+    if (!is.nnetar(model)) {
+      stop("Model must be a nnetar object")
+    }
+    # Check new data
+    m <- max(round(frequency(model$x)), 1L)
+    minlength <- max(c(model$p, model$P * m)) + 1
+    if (length(x) < minlength) {
+      stop(paste("Series must be at least of length", minlength, "to use fitted model"))
+    }
+    if (tsp(as.ts(x))[3] != m) {
+      warning(paste("Data frequency doesn't match fitted model, coercing to frequency =", m))
+      x <- ts(x, frequency = m)
+    }
+    # Check xreg
+    if (!is.null(model$xreg)) {
+      if (is.null(xreg)) {
+        stop("No external regressors provided")
+      }
+      if (NCOL(xreg) != NCOL(model$xreg)) {
+        stop("Number of external regressors does not match fitted model")
+      }
+    }
+    # Update parameters with previous model
+    lambda <- model$lambda
+    size <- model$size
+    p <- model$p
+    P <- model$P
+    if (P > 0) {
+      lags <- sort(unique(c(1:p, m * (1:P))))
+    } else {
+      lags <- 1:p
+    }
+    if (is.null(model$scalex)) {
+      scale.inputs <- FALSE
+    }
+  } else {                 # when not using an old model
+    if (length(y) < 3) {
+      stop("Not enough data to fit a model")
+    }
+    # Check for constant data in time series
+    constant_data <- is.constant(na.interp(x))
+    if (constant_data){
+      warning("Constant data, setting p=1, P=0, lambda=NULL, scale.inputs=FALSE")
+      scale.inputs <- FALSE
+      lambda <- NULL
+      p <- 1
+      P <- 0
+    }
+    ## Check for constant data in xreg
+    if (!is.null(xreg)){
+      constant_xreg <- any(apply(as.matrix(xreg), 2, function(x) is.constant(na.interp(x))))
+      if (constant_xreg){
+        warning("Constant xreg column, setting scale.inputs=FALSE")
+        scale.inputs <- FALSE
+      }
+    }
+  }
+
+  # Check for NAs in x
+  if (any(is.na(x))) {
+    warning("Missing values in x, omitting rows")
+  }
+
+  # Transform data
+  if (!is.null(lambda)) {
+    xx <- BoxCox(x, lambda)
+    lambda <- attr(xx, "lambda")
+  } else {
+    xx <- x
+  }
+  ## Check whether to use a subset of the data
+  xsub <- rep(TRUE, length(x))
+  if (is.numeric(subset)) {
+    xsub[-subset] <- FALSE
+  }
+  if (is.logical(subset)) {
+    xsub <- subset
+  }
+  # Scale series
+  scalex <- NULL
+  if (scale.inputs) {
+    if (useoldmodel) {
+      scalex <- model$scalex
+    }
+    else {
+      tmpx <- scale(xx[xsub], center = TRUE, scale = TRUE)
+      scalex <- list(
+        center = attr(tmpx, "scaled:center"),
+        scale = attr(tmpx, "scaled:scale")
+      )
+    }
+    xx <- scale(xx, center = scalex$center, scale = scalex$scale)
+    xx <- xx[, 1]
+  }
+  # Check xreg class & dim
+  xxreg <- NULL
+  scalexreg <- NULL
+  if (!is.null(xreg)) {
+    xxreg <- xreg <- as.matrix(xreg)
+    if (length(x) != NROW(xreg)) {
+      stop("Number of rows in xreg does not match series length")
+    }
+    # Check for NAs in xreg
+    if (any(is.na(xreg))) {
+      warning("Missing values in xreg, omitting rows")
+    }
+    # Scale xreg
+    if (scale.inputs) {
+      if (useoldmodel) {
+        scalexreg <- model$scalexreg
+      }
+      else {
+        tmpx <- scale(xxreg[xsub, ], center = TRUE, scale = TRUE)
+        scalexreg <- list(
+          center = attr(tmpx, "scaled:center"),
+          scale = attr(tmpx, "scaled:scale")
+        )
+      }
+      xxreg <- scale(xxreg, center = scalexreg$center, scale = scalexreg$scale)
+    }
+  }
+  # Set up lagged matrix
+  n <- length(xx)
+  xx <- as.ts(xx)
+  m <- max(round(frequency(xx)), 1L)
+  if (!useoldmodel) {
+    if (m == 1) {
+      if (missing(p)) {
+        p <- max(length(ar(na.interp(xx))$ar), 1)
+      }
+      if (p >= n) {
+        warning("Reducing number of lagged inputs due to short series")
+        p <- n - 1
+      }
+      lags <- 1:p
+      if (P > 1) {
+        warning("Non-seasonal data, ignoring seasonal lags")
+      }
+      P <- 0
+    } else {
+      if (missing(p)) {
+        if (n >= 2 * m) {
+          x.sa <- seasadj(mstl(na.interp(xx)))
+        } else {
+          x.sa <- na.interp(xx)
+        }
+        p <- max(length(ar(x.sa)$ar), 1)
+      }
+      if (p >= n) {
+        warning("Reducing number of lagged inputs due to short series")
+        p <- n - 1
+      }
+      if (P > 0 && n >= m * P + 2) {
+        lags <- sort(unique(c(1:p, m * (1:P))))
+      } else {
+        lags <- 1:p
+        if (P > 0) {
+          warning("Series too short for seasonal lags")
+          P <- 0
+        }
+      }
+    }
+  }
+  maxlag <- max(lags)
+  nlag <- length(lags)
+  y <- xx[-(1:maxlag)]
+  lags.X <- matrix(NA_real_, ncol = nlag, nrow = n - maxlag)
+  for (i in 1:nlag)
+    lags.X[, i] <- xx[(maxlag - lags[i] + 1):(n - lags[i])]
+  # Add xreg into lagged matrix
+  lags.X <- cbind(lags.X, xxreg[-(1:maxlag), ])
+  if (missing(size)) {
+    size <- round((NCOL(lags.X) + 1) / 2)
+  }
+  # Remove missing values if present
+  j <- complete.cases(lags.X, y)
+  ## Remove values not in subset
+  j <- j & xsub[-(1:maxlag)]
+  ## Stop if there's no data to fit (e.g. due to NAs or NaNs)
+  if (NROW(lags.X[j,, drop=FALSE]) == 0) {
+    stop("No data to fit (possibly due to NA or NaN)")
+  }
+  ## Fit average ANN.
+  if (useoldmodel) {
+    fit <- oldmodel_avnnet(lags.X[j, , drop = FALSE], y[j], size = size, model)
+  } else {
+    fit <- avnnet(lags.X[j, , drop=FALSE], y[j], size = size, repeats = repeats, ...)
+  }
+  # Return results
+  out <- list()
+  out$x <- as.ts(x)
+  out$m <- m
+  out$p <- p
+  out$P <- P
+  out$scalex <- scalex
+  out$scalexreg <- scalexreg
+  out$size <- size
+  out$xreg <- xreg
+  out$lambda <- lambda
+  out$subset <- (1:length(x))[xsub]
+  out$model <- fit
+  out$nnetargs <- list(...)
+  if (useoldmodel) {
+    out$nnetargs <- model$nnetargs
+  }
+  if (NROW(lags.X[j,, drop=FALSE]) == 1){
+    fits <- c(rep(NA_real_, maxlag), mean(sapply(fit, predict)))
+  } else{
+    fits <- c(rep(NA_real_, maxlag), rowMeans(sapply(fit, predict)))
+  }
+  if (scale.inputs) {
+    fits <- fits * scalex$scale + scalex$center
+  }
+  fits <- ts(fits)
+  if (!is.null(lambda)) {
+    fits <- InvBoxCox(fits, lambda)
+  }
+  out$fitted <- ts(rep(NA_real_, length(out$x)))
+  out$fitted[c(rep(TRUE, maxlag), j)] <- fits
+  tsp(out$fitted) <- tsp(out$x)
+  out$residuals <- out$x - out$fitted
+  out$lags <- lags
+  out$series <- yname
+  out$method <- paste("NNAR(", p, sep = "")
+  if (P > 0) {
+    out$method <- paste(out$method, ",", P, sep = "")
+  }
+  out$method <- paste(out$method, ",", size, ")", sep = "")
+  if (P > 0) {
+    out$method <- paste(out$method, "[", m, "]", sep = "")
+  }
+  out$call <- match.call()
+  return(structure(out, class = c("nnetar")))
+}
+
+
+#' Forecasting using neural network models
+#'
+#' Returns forecasts and other information for univariate neural network
+#' models.
+#'
+#' Prediction intervals are calculated through simulations and can be slow.
+#' Note that if the network is too complex and overfits the data, the residuals
+#' can be arbitrarily small; if used for prediction interval calculations, they
+#' could lead to misleadingly small values.
+#'
+#' @param object An object of class "\code{nnetar}" resulting from a call to
+#' \code{\link{arima}}.
+#' @param h Number of periods for forecasting. If \code{xreg} is used, \code{h}
+#' is ignored and the number of forecast periods is set to the number of rows
+#' of \code{xreg}.
+#' @param PI If TRUE, prediction intervals are produced, otherwise only point
+#' forecasts are calculated. If \code{PI} is FALSE, then \code{level},
+#' \code{fan}, \code{bootstrap} and \code{npaths} are all ignored.
+#' @param level Confidence level for prediction intervals.
+#' @param fan If \code{TRUE}, level is set to \code{seq(51,99,by=3)}. This is
+#' suitable for fan plots.
+#' @param xreg Future values of external regressor variables.
+#' @param bootstrap If \code{TRUE}, then prediction intervals computed using
+#' simulations with resampled residuals rather than normally distributed
+#' errors. Ignored if \code{innov} is not \code{NULL}.
+#' @param npaths Number of sample paths used in computing simulated prediction
+#' intervals.
+#' @param innov Values to use as innovations for prediction intervals. Must be
+#' a matrix with \code{h} rows and \code{npaths} columns (vectors are coerced
+#' into a matrix). If present, \code{bootstrap} is ignored.
+#' @param ... Additional arguments passed to \code{\link{simulate.nnetar}}
+#' @inheritParams forecast
+#'
+#' @return An object of class "\code{forecast}".
+#'
+#' The function \code{summary} is used to obtain and print a summary of the
+#' results, while the function \code{plot} produces a plot of the forecasts and
+#' prediction intervals.
+#'
+#' The generic accessor functions \code{fitted.values} and \code{residuals}
+#' extract useful features of the value returned by \code{forecast.nnetar}.
+#'
+#' An object of class "\code{forecast}" is a list containing at least the
+#' following elements:
+#'   \item{model}{A list containing information about the fitted model}
+#'   \item{method}{The name of the forecasting method as a character string}
+#'   \item{mean}{Point forecasts as a time series}
+#'   \item{lower}{Lower limits for prediction intervals}
+#'   \item{upper}{Upper limits for prediction intervals}
+#'   \item{level}{The confidence values associated with the prediction intervals}
+#'   \item{x}{The original time series (either \code{object} itself or the time series
+#'            used to create the model stored as \code{object}).}
+#'   \item{xreg}{The external regressors used in fitting (if given).}
+#'   \item{residuals}{Residuals from the fitted model. That is x minus fitted values.}
+#'   \item{fitted}{Fitted values (one-step forecasts)}
+#'   \item{...}{Other arguments}
+#'
+#' @author Rob J Hyndman
+#' @seealso \code{\link{nnetar}}.
+#' @keywords ts
+#' @examples
+#' fit <- nnetar(lynx)
+#' fcast <- forecast(fit)
+#' plot(fcast)
+#'
+#' @export
+forecast.nnetar <- function(object, h=ifelse(object$m > 1, 2 * object$m, 10), PI=FALSE, level=c(80, 95), fan=FALSE, xreg=NULL, lambda=object$lambda, bootstrap=FALSE, npaths=1000, innov=NULL, ...) {
+  #  require(nnet)
+  out <- object
+  tspx <- tsp(out$x)
+  #
+  if (fan) {
+    level <- seq(51, 99, by = 3)
+  } else {
+    if (min(level) > 0 && max(level) < 1) {
+      level <- 100 * level
+    } else if (min(level) < 0 || max(level) > 99.99) {
+      stop("Confidence limit out of range")
+    }
+  }
+  # Check if xreg was used in fitted model
+  if (is.null(object$xreg)) {
+    if (!is.null(xreg)) {
+      warning("External regressors were not used in fitted model, xreg will be ignored")
+    }
+    xreg <- NULL
+  }
+  else {
+    if (is.null(xreg)) {
+      stop("No external regressors provided")
+    }
+    xreg <- as.matrix(xreg)
+    if (NCOL(xreg) != NCOL(object$xreg)) {
+      stop("Number of external regressors does not match fitted model")
+    }
+    h <- NROW(xreg)
+  }
+  fcast <- numeric(h)
+  xx <- object$x
+  xxreg <- xreg
+  if (!is.null(lambda)) {
+    xx <- BoxCox(xx, lambda)
+    lambda <- attr(xx, "lambda")
+  }
+  # Check and apply scaling of fitted model
+  if (!is.null(object$scalex)) {
+    xx <- scale(xx, center = object$scalex$center, scale = object$scalex$scale)
+    if (!is.null(xreg)) {
+      xxreg <- scale(xreg, center = object$scalexreg$center, scale = object$scalexreg$scale)
+    }
+  }
+
+  # Get lags used in fitted model
+  lags <- object$lags
+  maxlag <- max(lags)
+  flag <- rev(tail(xx, n = maxlag))
+  # Iterative 1-step forecast
+  for (i in 1:h)
+  {
+    newdata <- c(flag[lags], xxreg[i, ])
+    if (any(is.na(newdata))) {
+      stop("I can't forecast when there are missing values near the end of the series.")
+    }
+    fcast[i] <- mean(sapply(object$model, predict, newdata = newdata))
+    flag <- c(fcast[i], flag[-maxlag])
+  }
+  # Re-scale point forecasts
+  if (!is.null(object$scalex)) {
+    fcast <- fcast * object$scalex$scale + object$scalex$center
+  }
+  # Add ts properties
+  fcast <- ts(fcast, start = tspx[2] + 1 / tspx[3], frequency = tspx[3])
+  # Back-transform point forecasts
+  if (!is.null(lambda)) {
+    fcast <- InvBoxCox(fcast, lambda)
+  }
+  # Compute prediction intervals using simulations
+  if (isTRUE(PI)) {
+    nint <- length(level)
+    sim <- matrix(NA, nrow = npaths, ncol = h)
+    if (!is.null(innov)) {
+      if (length(innov) != h * npaths) {
+        stop("Incorrect number of innovations, need h*npaths values")
+      }
+      innov <- matrix(innov, nrow = h, ncol = npaths)
+      bootstrap <- FALSE
+    }
+    for (i in 1:npaths)
+      sim[i, ] <- simulate(object, nsim = h, bootstrap = bootstrap, xreg = xreg, lambda = lambda, innov = innov[, i], ...)
+    lower <- apply(sim, 2, quantile, 0.5 - level / 200, type = 8)
+    upper <- apply(sim, 2, quantile, 0.5 + level / 200, type = 8)
+    if (nint > 1L) {
+      lower <- ts(t(lower))
+      upper <- ts(t(upper))
+    }
+    else {
+      lower <- ts(matrix(lower, ncol = 1L))
+      upper <- ts(matrix(upper, ncol = 1L))
+    }
+    tsp(lower) <- tsp(upper) <- tsp(fcast)
+  }
+  else {
+    level <- NULL
+    lower <- NULL
+    upper <- NULL
+  }
+  out$mean <- fcast
+  out$level <- level
+  out$lower <- lower
+  out$upper <- upper
+  return(structure(out, class = "forecast"))
+}
+
+#' @rdname fitted.Arima
+#' @export
+fitted.nnetar <- function(object, h=1, ...) {
+  if (h == 1) {
+    return(object$fitted)
+  }
+  else {
+    return(hfitted(object = object, h = h, FUN = "nnetar", ...))
+  }
+}
+
+#' @export
+print.nnetar <- function(x, digits = max(3, getOption("digits") - 3), ...) {
+  cat("Series:", x$series, "\n")
+  cat("Model: ", x$method, "\n")
+  # cat("  one hidden layer with",x$size,"nodes\n")
+  cat("Call:   ")
+  print(x$call)
+  print(x$model)
+  cat(
+    "\nsigma^2 estimated as ", format(mean(residuals(x) ^ 2, na.rm = TRUE), digits = digits),
+    "\n", sep = ""
+  )
+  invisible(x)
+}
+
+#' @rdname is.ets
+#' @export
+is.nnetar <- function(x) {
+  inherits(x, "nnetar")
+}

--- a/R/modelAR.R
+++ b/R/modelAR.R
@@ -113,8 +113,8 @@ modelAR <- function(y, p, P=1, FUN, predict.FUN, xreg=NULL, lambda=NULL, model=N
     } else {
       lags <- 1:p
     }
-    if (is.null(model$scalex)) {
-      scale.inputs <- FALSE
+    if (!is.null(model$scalex)) {
+      scale.inputs <- TRUE
     }
   } else {                 # when not using an old model
     if (length(y) < 3) {

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -429,7 +429,7 @@ print.nnetarmodels <- function(x, ...) {
 #'   \item{fitted}{Fitted values (one-step forecasts)}
 #'   \item{...}{Other arguments}
 #'
-#' @author Rob J Hyndman
+#' @author Rob J Hyndman and Gabriel Caceres
 #' @seealso \code{\link{nnetar}}.
 #' @keywords ts
 #' @examples

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -655,7 +655,7 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
 
 #' @rdname simulate.ets
 #' @export
-simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL, future=TRUE, bootstrap=FALSE, innov=NULL, lambda=object$lambda, ...) {
+simulate.modelAR <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL, future=TRUE, bootstrap=FALSE, innov=NULL, lambda=object$lambda, ...) {
   if (is.null(innov)) {
     if (!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
       runif(1)
@@ -749,7 +749,7 @@ simulate.nnetar <- function(object, nsim=length(object$x), seed=NULL, xreg=NULL,
     if (any(is.na(newdata))) {
       stop("I can't simulate when there are missing values near the end of the series.")
     }
-    path[i] <- mean(sapply(object$model, predict, newdata = newdata)) + e[i]
+    path[i] <- object$predict.FUN(object$model, newdata) + e[i]
     flag <- c(path[i], flag[-maxlag])
   }
   ## Re-scale simulated points

--- a/tests/testthat/test-modelAR.R
+++ b/tests/testthat/test-modelAR.R
@@ -1,0 +1,187 @@
+# A unit test for modelAR.R
+if (require(testthat)) {
+  context("Testing modelAR")
+  test_that("Tests for modelAR", {
+    ## Set up functions to match 'nnetar' behavior
+    avnnet2 <- function(x, y, repeats = repeats, linout=TRUE, trace=FALSE, ...){
+      mods <- list()
+      for (i in 1:repeats)
+        mods[[i]] <- nnet::nnet(x, y, linout = linout, trace = trace, ...)
+      return(structure(mods, class = "nnetarmodels"))
+    }
+    ##
+    predict.avnnet2 <- function(model, newdata=NULL){
+      if (is.null(newdata)){
+        if (length(predict(model[[1]])) > 1) {
+          rowMeans(sapply(model, predict))
+        } else {
+          mean(sapply(model, predict))
+        }
+      } else {
+        if (NCOL(newdata) >= 2 & NROW(newdata) >= 2){
+          rowMeans(sapply(model, predict, newdata=newdata))
+        } else {
+          mean(sapply(model, predict, newdata=newdata))
+        }
+      }
+    }
+    ## compare residuals to 'nnetar'
+    expect_silent({
+      set.seed(123)
+      nnetar_model <- nnetar(lynx[1:100], p=2, P=1, size=3, repeats=20)
+      set.seed(123)
+      modelAR_model <- modelAR(lynx[1:100], FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=1, scale.inputs = TRUE, size=3, repeats=20)
+      res1 <- residuals(nnetar_model)
+      res2 <- residuals(modelAR_model)
+    })
+    expect_true(identical(res1, res2))
+    ## check re-fitting old model and compare to 'nnetar'
+    expect_silent({
+      nnetar_model2 <- nnetar(lynx[101:114], model=nnetar_model)
+      modelAR_model2 <- modelAR(lynx[101:114], FUN = avnnet2, predict.FUN= predict.avnnet2, model=modelAR_model)
+      res1 <- residuals(nnetar_model2)
+      res2 <- residuals(modelAR_model2)
+    })
+    expect_true(identical(res1, res2))
+    ## compare forecasts with 'nnetar'
+    expect_silent({
+      f1 <- forecast(nnetar_model)$mean
+      f2 <- forecast(modelAR_model)$mean
+    })
+    expect_true(identical(f1, f2))
+    ## test lambda and compare to 'nnetar'
+    expect_silent({
+      set.seed(123)
+      oilnnet_nnetar  <- nnetar(airmiles, lambda = 0.15, size = 1, repeats=20)
+      set.seed(123)
+      oilnnet_modelAR  <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, lambda = 0.15, size = 1, repeats=20)
+    })
+    expect_true(identical(residuals(oilnnet_nnetar, type = "response"), residuals(oilnnet_modelAR, type = "response")))
+    expect_true(length(forecast(oilnnet_modelAR)$mean) == 10)
+    ## check print input name
+    expect_silent(woolyrnqnnet <- modelAR(woolyrnq, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, p = 1, P = 0, size = 8, repeats = 10))
+    expect_output(print(woolyrnqnnet), regexp = "Series: woolyrnq")
+    ## check default forecast length
+    expect_true(length(forecast(woolyrnqnnet)$mean) == 2 * frequency(woolyrnq))
+    #
+    # Test with single-column xreg (which might be a vector)
+    expect_silent({
+      set.seed(123)
+      woolyrnqnnet <- modelAR(woolyrnq, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = 1:length(woolyrnq), p = 2, P = 2, size = 4, repeats = 10)
+      set.seed(123)
+      woolyrnqnnet2 <- nnetar(woolyrnq, xreg = 1:length(woolyrnq), p = 2, P = 2, size = 4, repeats = 10)
+    })
+    expect_true(all(dim(woolyrnqnnet$xreg) == c(119, 1)))
+    expect_true(length(forecast(woolyrnqnnet, xreg = 120:130)$mean) == 11)
+    expect_true(identical(forecast(woolyrnqnnet, xreg = 120:130)$mean, forecast(woolyrnqnnet2, xreg = 120:130)$mean))
+    ## Test with multiple-column xreg
+    expect_silent({
+      set.seed(123)
+      winennet <- modelAR(wineind, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE,  xreg = cbind(bizdays(wineind), fourier(wineind, 1)), p = 2, P = 1, size = 4, repeats = 10)
+      set.seed(123)
+      winennet2 <- nnetar(
+          wineind,
+          xreg = cbind(bizdays(wineind), fourier(wineind, 1)),
+          p = 2, P=1, size = 4, repeats = 10
+          )
+    })
+    expect_true(length(forecast(winennet, h = 2, xreg = matrix(2, 2, 3))$mean) == 2L)
+    ## Test if h matches xreg
+    expect_true(length(forecast(winennet, h = 5, xreg = matrix(2, 2, 3))$mean) == 2L)
+    expect_true(identical(forecast(winennet2, xreg = matrix(2, 2, 3))$mean, forecast(winennet, xreg = matrix(2, 2, 3))$mean))
+    ## Test that P is ignored if m=1
+    expect_warning(wwwnnet <- modelAR(WWWusage, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = 1:length(WWWusage), p = 2, P = 4, size = 3, repeats = 10))
+    ## Test passing arguments to nnet
+    expect_silent({
+      set.seed(123)
+      wwwnnet <- modelAR(WWWusage, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = 1:length(WWWusage), p = 2, P = 0, size = 3, decay = 0.1, repeats = 10)
+      set.seed(123)
+      wwwnnet2 <- nnetar(WWWusage, size = 3, p = 2, P = 0, xreg = 1:length(WWWusage), decay = 0.1, repeats = 10)
+    })
+    expect_true(identical(forecast(wwwnnet, h=2, xreg = (length(WWWusage)+1):(length(WWWusage)+5))$mean,
+              forecast(wwwnnet2, h=2, xreg = (length(WWWusage)+1):(length(WWWusage)+5))$mean
+              ))
+    ## Test output format correct when NAs present
+    airna <- airmiles
+    airna[12] <- NA
+    expect_warning(airnnet <- modelAR(airna, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, p = 1, size = 0, skip = TRUE, Wts = c(0, 1), maxit = 0, repeats = 5))
+    expect_true(identical(airnnet$fitted[-c(1, 12, 13)], airna[-c(11, 12, length(airna))]))
+    ## Test model argument
+    expect_silent({
+      set.seed(123)
+      fit1 <- modelAR(
+          WWWusage, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE,
+          xreg = 1:length(WWWusage),
+          p = 3, size=2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7
+          )
+      fit2 <- modelAR(WWWusage, xreg = 1:length(WWWusage), model = fit1)
+      set.seed(123)
+      fit3 <- nnetar(WWWusage, xreg = 1:length(WWWusage), p = 3, size=2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7)
+    })
+    # Check some model parameters
+    expect_true(identical(fit1$p, fit2$p))
+    expect_true(identical(fit1$lambda, fit2$lambda))
+    expect_true(identical(fit1$modelargs, fit2$modelargs))
+    # Check fitted values are all the same
+    expect_true(identical(fitted(fit1), fitted(fit2)))
+    expect_true(identical(fitted(fit1, h=2), fitted(fit2, h=2)))
+    # Check residuals all the same
+    expect_true(identical(residuals(fit1), residuals(fit2)))
+    # Check number of neural nets
+    expect_true(identical(length(fit1$model), length(fit2$model)))
+    # Check neural network weights all the same
+    expect_true(identical(fit1$model[[1]]$wts, fit2$model[[1]]$wts))
+    expect_true(identical(fit1$model[[7]]$wts, fit2$model[[7]]$wts))
+    ## compare results with 'nnetar'
+    expect_true(identical(fitted(fit1), fitted(fit3)))
+    expect_true(identical(fitted(fit1, h=3), fitted(fit3, h=3)))
+    expect_true(identical(residuals(fit1, type="response"), residuals(fit3, type="response")))
+    ## Check subset argument using indices
+    expect_silent({
+      set.seed(123)
+      airnnet <- modelAR(airmiles, , FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = 11:20, p=1, size=1, repeats=10)
+      set.seed(123)
+      airnnet2 <- nnetar(airmiles, , subset = 11:20, p=1, size=1, repeats=10)
+    })
+    expect_true(identical(which(!is.na(fitted(airnnet))), 11:20))
+    expect_true(identical(fitted(airnnet), fitted(airnnet2)))
+    expect_true(identical(forecast(airnnet, h=5)$mean, forecast(airnnet2, h=5)$mean))
+    ## Check subset argument using logical vector
+    expect_silent({
+      set.seed(123)
+      airnnet <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p=1, size=1, repeats=10)
+      set.seed(123)
+      airnnet2 <- nnetar(airmiles, , subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p=1, size=1, repeats=10)
+    })
+    expect_true(identical(which(!is.na(fitted(airnnet))), 11:20))
+    expect_true(identical(fitted(airnnet), fitted(airnnet2)))
+    expect_true(identical(forecast(airnnet, h=5)$mean, forecast(airnnet2, h=5)$mean))
+    ## compare prediction intervals with 'nnetar'
+    expect_silent({
+      set.seed(456)
+      f1 <- forecast(airnnet, h=5, PI=TRUE, npaths=100)
+      set.seed(456)
+      f2 <- forecast(airnnet2, h=5, PI=TRUE, npaths=100)
+    })
+    expect_true(identical(f1$upper, f2$upper))
+    expect_true(identical(f1$lower, f2$lower))
+    ## Check short and constant data
+    expect_warning(nnetfit <- modelAR(rep(1, 10), FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant data")
+    expect_true(nnetfit$p == 1)
+    expect_true(is.null(nnetfit$lambda))
+    expect_true(is.null(nnetfit$scalex))
+    expect_error(nnetfit <- modelAR(rnorm(2), FUN = avnnet2, predict.FUN = predict.avnnet2, p=1, P=0, size=1, repeats=1), "Not enough data")
+    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=1, P=0, size=1, repeats=1))
+    expect_true(nnetfit$p == 1)
+    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=0, size=1, repeats=1))
+    expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=3, P=0, size=1, repeats=1), "short series")
+    expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=4, P=0, size=1, repeats=1), "short series")
+    expect_true(nnetfit$p == 2)
+    expect_warning(nnetfit <- modelAR(rnorm(10), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg=rep(1, 10), p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_true(is.null(nnetfit$scalexreg))
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg=matrix(c(1, 2, 3, 1, 1, 1), ncol=2), p=1, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_true(is.null(nnetfit$scalexreg))
+  })
+}


### PR DESCRIPTION
This adds functionality to forecast with a user-defined function in a manner similar to `nnetar`, as referenced in #668. I took advantage of the existing `nnetar` code, with some tweaking to use (in principle) any function. It does require a bit more effort from the user in terms of defining the function correctly. The PR includes `modelAR` (what I named the function, although happy hear suggestions), `forecast.modelAR`, `simulate.modelAR`, and unit tests for them. Most unit tests are almost identical to the ones for `nnetar`, plus some additional ones tho compare that output from both functions is identical (given an appropriately defined `FUN` argument for `modelAR`). Although not included here, `CVar` should be straightforward to extend to work with `modelAR`.

Some things are still a bit rough around the edges but see what you think.

Using `modelAR` one can do things like:
```
## Random Forest Example
library(randomForest)
set.seed(1234)
modelAR_rf <- modelAR(window(lynx, end=1920), FUN = randomForest, predict.FUN= predict, p=3, P=0)
print(modelAR_rf)
plot(forecast(modelAR_rf, h=15, PI=T, npaths=500))
lines(lynx, lty=2)

## And also apply an old model
modelAR_rf2 <- modelAR(lynx, FUN = randomForest, predict.FUN= predict, model=modelAR_rf)
plot(forecast(modelAR_rf2, h=15, PI=T, npaths=500))
```

`randomForest` is easy since by default it works as `FUN(x,y,...)` and the `predict` method doesn't need additional tweaking. Other functions might be a bit more complex; for example, `glm` is a bit trickier due to using a formula and needing the inputs to be a data frame with the same feature names. Here's an example implementation of that:

```
## GLM
my_glm <- function(x, y, ...){
  glm(y~., data=data.frame(x), ...)
}
predict.my_glm <- function(model, newdata=NULL){
  if (is.null(newdata)){
    predict(model, type="response")
  } else{
    mycols <- names(coef(model))[-1]
    mydat <- matrix(newdata, ncol=length(mycols))
    colnames(mydat) <- mycols
    predict(model, newdata=data.frame(mydat), type="response")
  }
}

```

which we can compare with a simple AR model as a sanity check

```
arima_model <- Arima(lynx, order=c(2, 0, 0))
modelAR_glm <- modelAR(lynx, FUN = my_glm, predict.FUN= predict.my_lm, p=2, P=0, family=gaussian)

## Coefficients are very similar (as expected)
print(arima_model)
print(modelAR_lm)
## So are forecasts
cbind(forecast(arima_model, h=5)$mean, forecast(modelAR_lm, h=5)$mean)
## And confidence intervals
par(mfcol=c(1, 2))
plot(forecast(arima_model, h=15))
plot(forecast(modelAR_lm, h=15, PI=T, npaths=1000))

```

Finally let me compare it with `nnetar` to make sure the output is correct (the function here is a bit more cumbersome since I had to account for various cases—like short data—to make sure both functions matched up). 

```
avnnet2 <- function(x, y, repeats = repeats, linout=TRUE, trace=FALSE, ...){
  mods <- list()
  for (i in 1:repeats)
    mods[[i]] <- nnet::nnet(x, y, linout = linout, trace = trace, ...)
  return(structure(mods, class = "nnetarmodels"))
}
##
predict.avnnet2 <- function(model, newdata=NULL){
  if (is.null(newdata)){
    if (length(predict(model[[1]])) > 1) {
      rowMeans(sapply(model, predict))
    } else {
      mean(sapply(model, predict))
    }
  } else {
    if (NCOL(newdata) >= 2 & NROW(newdata) >= 2){
      rowMeans(sapply(model, predict, newdata=newdata))
    } else {
      mean(sapply(model, predict, newdata=newdata))
    }
  }
}

```
The two functions above are included in 'test-modelAR.R' for the unit tests comparing `modelAR` and `nnetar`.  Below is another short comparison of the two

```
## Compare `modelAR` fit with `nnetar`
set.seed(123)
nnetar_model <- nnetar(lynx[1:100], p=2, P=1, size=3, repeats=20)
set.seed(123)
modelAR_model <- modelAR(lynx[1:100], FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=1, size=3, repeats=20)
##
nnetar_model2 <- nnetar(lynx[101:114], model=nnetar_model)
modelAR_model2 <- modelAR(lynx[101:114], FUN = avnnet2, predict.FUN= predict.avnnet2, model=modelAR_model)

## All identical results
identical(residuals(nnetar_model), residuals(modelAR_model))
identical(residuals(nnetar_model2), residuals(modelAR_model2))
identical(forecast(nnetar_model)$mean, forecast(modelAR_model)$mean)

```

