### PR TITLE
Fixed naive, rwf, snaive lambda argument

### DIFF
--- a/R/naive.R
+++ b/R/naive.R
@@ -175,7 +175,7 @@ rwf <- function(y, h=10, drift=FALSE, level=c(80, 95), fan=FALSE, lambda=NULL, b
   
   fc <- forecast(fit, h = h,
                  level = level, fan = fan,
-                 lambda = lambda, biasadj = biasadj, ...)
+                 lambda = fit$lambda, biasadj = biasadj, ...)
   
   fc$model$call <- match.call()
   fc$series <- deparse(substitute(y))
@@ -274,7 +274,7 @@ snaive <- function(y, h=2 * frequency(x), level=c(80, 95), fan=FALSE, lambda=NUL
   )
   fc <- forecast(fit, h = h,
                  level = level, fan = fan,
-                 lambda = lambda, biasadj = biasadj, ...)
+                 lambda = fit$lambda, biasadj = biasadj, ...)
   fc$model$call <- match.call()
   fc$series <- deparse(substitute(y))
   fc$method <- "Seasonal naive method"


### PR DESCRIPTION
Hello,

I noticed `naive`, `rwf` and `snaive` fail with `lambda = "auto"`. It seems to come from the following commit <https://github.com/robjhyndman/forecast/commit/36c9eeb6625b47c6b4586328d17a81d769237af8>. 

For example:
``` r
library(forecast)

naive(airmiles, lambda = "auto")
#> Error in x * lambda: non-numeric argument to binary operator
rwf(airmiles, lambda = "auto")
#> Error in x * lambda: non-numeric argument to binary operator
snaive(airmiles, lambda = "auto")
#> Error in x * lambda: non-numeric argument to binary operator
```
<sup>Created on 2019-01-21 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

This pull request fixes the issue.