### PR TITLE
Rectify partial match warnings

### DIFF
--- a/R/HoltWintersNew.R
+++ b/R/HoltWintersNew.R
@@ -148,13 +148,13 @@ HoltWintersZZ <- function(x,
       }
     }
     if (select[1] > 0) {
-      alpha <- sol$p[1L]
+      alpha <- sol$par[1L]
     }
     if (select[2] > 0) {
-      beta <- sol$p[1L + select[1]]
+      beta <- sol$par[1L + select[1]]
     }
     if (select[3] > 0) {
-      gamma <- sol$p[1L + select[1] + select[2]]
+      gamma <- sol$par[1L + select[1] + select[2]]
     }
   }
 

--- a/R/arima.R
+++ b/R/arima.R
@@ -787,7 +787,7 @@ arima2 <- function(x, model, xreg, method) {
   sigma2 <- model$sigma2
   if (use.drift) {
     driftmod <- lm(model$xreg[, "drift"] ~ I(time(as.ts(model$x))))
-    newxreg <- driftmod$coeff[1] + driftmod$coeff[2] * time(as.ts(x))
+    newxreg <- driftmod$coefficients[1] + driftmod$coefficients[2] * time(as.ts(x))
     if (!is.null(xreg)) {
       origColNames <- colnames(xreg)
       xreg <- cbind(newxreg, xreg)

--- a/R/armaroots.R
+++ b/R/armaroots.R
@@ -52,7 +52,7 @@ plot.armaroots <- function(x, xlab, ylab, main, ...) {
   )
   axis(1, at = c(-1, 0, 1), line = 0.5, tck = -0.025)
   axis(2, at = c(-1, 0, 1), labels = c("-i", "0", "i"), line = 0.5, tck = -0.025)
-  circx <- seq(-1, 1, l = 501)
+  circx <- seq(-1, 1, length.out = 501)
   circy <- sqrt(1 - circx ^ 2)
   lines(c(circx, circx), c(circy, -circy), col = "gray")
   lines(c(-2, 2), c(0, 0), col = "gray")

--- a/R/armaroots.R
+++ b/R/armaroots.R
@@ -47,13 +47,14 @@ plot.armaroots <- function(x, xlab, ylab, main, ...) {
   oldpar <- par(pty = "s")
   on.exit(par(oldpar))
   plot(
-    c(-1, 1), c(-1, 1), xlab = xlab, ylab = ylab,
+    c(-1, 1), c(-1, 1),
+    xlab = xlab, ylab = ylab,
     type = "n", bty = "n", xaxt = "n", yaxt = "n", main = main, ...
   )
   axis(1, at = c(-1, 0, 1), line = 0.5, tck = -0.025)
   axis(2, at = c(-1, 0, 1), labels = c("-i", "0", "i"), line = 0.5, tck = -0.025)
   circx <- seq(-1, 1, length.out = 501)
-  circy <- sqrt(1 - circx ^ 2)
+  circy <- sqrt(1 - circx^2)
   lines(c(circx, circx), c(circy, -circy), col = "gray")
   lines(c(-2, 2), c(0, 0), col = "gray")
   lines(c(0, 0), c(-2, 2), col = "gray")
@@ -92,20 +93,19 @@ plot.armaroots <- function(x, xlab, ylab, main, ...) {
 #'
 #' library(ggplot2)
 #'
-#' fit <- Arima(WWWusage, order=c(3,1,0))
+#' fit <- Arima(WWWusage, order = c(3, 1, 0))
 #' plot(fit)
 #' autoplot(fit)
 #'
-#' fit <- Arima(woolyrnq,order=c(2,0,0),seasonal=c(2,1,1))
+#' fit <- Arima(woolyrnq, order = c(2, 0, 0), seasonal = c(2, 1, 1))
 #' plot(fit)
 #' autoplot(fit)
 #'
 #' plot(ar.ols(gold[1:61]))
 #' autoplot(ar.ols(gold[1:61]))
-#'
 #' @export
-plot.Arima <- function(x, type=c("both", "ar", "ma"), main,
-                       xlab="Real", ylab="Imaginary", ...) {
+plot.Arima <- function(x, type = c("both", "ar", "ma"), main,
+                       xlab = "Real", ylab = "Imaginary", ...) {
   type <- match.arg(type)
   if (!is.element("Arima", class(x))) {
     stop("This function is for objects of class 'Arima'.")
@@ -137,7 +137,7 @@ plot.Arima <- function(x, type=c("both", "ar", "ma"), main,
   }
   if ((type == "ar" && (p == 0)) || (type == "ma" && (q == 0)) || (p == 0 && q == 0)) {
     warning("No roots to plot")
-    if(missing(main)){
+    if (missing(main)) {
       main <- "No AR or MA roots"
     }
   }
@@ -157,7 +157,7 @@ plot.Arima <- function(x, type=c("both", "ar", "ma"), main,
 
 #' @rdname plot.Arima
 #' @export
-plot.ar <- function(x, main, xlab="Real", ylab="Imaginary", ...) {
+plot.ar <- function(x, main, xlab = "Real", ylab = "Imaginary", ...) {
   if (!is.element("ar", class(x))) {
     stop("This function is for objects of class 'ar'.")
   }

--- a/R/bats.R
+++ b/R/bats.R
@@ -428,7 +428,7 @@ plot.bats <- function(x, main="Decomposition by BATS model", ...) {
   }
   nonseas <- 2 + !is.null(x$beta) # No. non-seasonal columns in out
   nseas <- length(x$gamma.values) # No. seasonal periods
-  if (!is.null(x$gamma)) {
+  if (!is.null(x$gamma.values)) {
     seas.states <- x$x[-(1:(1 + !is.null(x$beta))), ]
     j <- cumsum(c(1, x$seasonal.periods))
     for (i in 1:nseas)

--- a/R/bats.R
+++ b/R/bats.R
@@ -63,12 +63,13 @@
 #' plot(forecast(fit))
 #'
 #' taylor.fit <- bats(taylor)
-#' plot(forecast(taylor.fit))}
+#' plot(forecast(taylor.fit))
+#' }
 #'
 #' @export
-bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
-                 seasonal.periods=NULL, use.arma.errors=TRUE, use.parallel=length(y) > 1000, num.cores=2,
-                 bc.lower=0, bc.upper=1, biasadj = FALSE, model=NULL, ...) {
+bats <- function(y, use.box.cox = NULL, use.trend = NULL, use.damped.trend = NULL,
+                 seasonal.periods = NULL, use.arma.errors = TRUE, use.parallel = length(y) > 1000, num.cores = 2,
+                 bc.lower = 0, bc.upper = 1, biasadj = FALSE, model = NULL, ...) {
   if (!is.numeric(y) || NCOL(y) > 1) {
     stop("y should be a univariate time series")
   }
@@ -213,7 +214,8 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
       for (trend in use.trend) {
         for (damping in use.damped.trend) {
           current.model <- filterSpecifics(
-            y, box.cox = box.cox, trend = trend, damping = damping,
+            y,
+            box.cox = box.cox, trend = trend, damping = damping,
             seasonal.periods = seasonal.periods, use.arma.errors = use.arma.errors,
             init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj, ...
           )
@@ -243,7 +245,7 @@ bats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
 }
 
 filterSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, use.arma.errors,
-                            force.seasonality=FALSE, init.box.cox=NULL, bc.lower=0, bc.upper=1, biasadj=FALSE, ...) {
+                            force.seasonality = FALSE, init.box.cox = NULL, bc.lower = 0, bc.upper = 1, biasadj = FALSE, ...) {
   if (!trend && damping) {
     return(list(AIC = Inf))
   }
@@ -288,7 +290,7 @@ filterSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, use.ar
   }
 }
 
-parFilterSpecifics <- function(control.number, control.array, y, seasonal.periods, use.arma.errors, force.seasonality=FALSE, init.box.cox=NULL, bc.lower=0, bc.upper=1, biasadj=FALSE, ...) {
+parFilterSpecifics <- function(control.number, control.array, y, seasonal.periods, use.arma.errors, force.seasonality = FALSE, init.box.cox = NULL, bc.lower = 0, bc.upper = 1, biasadj = FALSE, ...) {
   box.cox <- control.array[control.number, 1]
   trend <- control.array[control.number, 2]
   damping <- control.array[control.number, 3]
@@ -340,7 +342,7 @@ parFilterSpecifics <- function(control.number, control.array, y, seasonal.period
 
 #' @rdname fitted.Arima
 #' @export
-fitted.bats <- function(object, h=1, ...) {
+fitted.bats <- function(object, h = 1, ...) {
   if (h == 1) {
     return(object$fitted.values)
   }
@@ -412,7 +414,7 @@ print.bats <- function(x, ...) {
 #' @keywords hplot
 #'
 #' @export
-plot.bats <- function(x, main="Decomposition by BATS model", ...) {
+plot.bats <- function(x, main = "Decomposition by BATS model", ...) {
   # Get original data, transform if necessary
   if (!is.null(x$lambda)) {
     y <- BoxCox(x$y, x$lambda)
@@ -431,8 +433,9 @@ plot.bats <- function(x, main="Decomposition by BATS model", ...) {
   if (!is.null(x$gamma.values)) {
     seas.states <- x$x[-(1:(1 + !is.null(x$beta))), ]
     j <- cumsum(c(1, x$seasonal.periods))
-    for (i in 1:nseas)
+    for (i in 1:nseas) {
       out <- cbind(out, season = seas.states[j[i], ])
+    }
     if (nseas > 1) {
       colnames(out)[nonseas + 1:nseas] <- paste("season", 1:nseas, sep = "")
     }

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -58,7 +58,7 @@ bizdays <- function(x, FinCenter = c(
   if (freq == 12L) { # monthly data
     date <- zoo::as.Date(time(x))
     start <- date[1L]
-    end <- seq(date[length(date)], length = 2L, by = "month")[2L] - 1L
+    end <- seq(date[length(date)], length.out = 2L, by = "month")[2L] - 1L
     days.len <- timeDate::timeSequence(from = start, to = end)
     # Grab business days
     biz <- days.len[timeDate::isBizday(days.len, holidays = holidays)]
@@ -66,7 +66,7 @@ bizdays <- function(x, FinCenter = c(
   } else if (freq == 4L) { # Quarterly data
     date <- zoo::as.Date(time(x))
     start <- date[1L]
-    end <- seq(date[length(date)], length = 2L, by = "3 month")[2L] - 1L
+    end <- seq(date[length(date)], length.out = 2L, by = "3 month")[2L] - 1L
     days.len <- timeDate::timeSequence(from = start, to = end)
     # Grab business days
     biz <- days.len[timeDate::isBizday(days.len, holidays = holidays)]

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -20,14 +20,13 @@ as.Date.timeDate <- timeDate::as.Date.timeDate
 #' @keywords ts
 #' @examples
 #'
-#'   x <-  ts(rnorm(30), start = c(2013, 2), frequency = 12)
-#'   bizdays(x, FinCenter = "New York")
-#'
+#' x <- ts(rnorm(30), start = c(2013, 2), frequency = 12)
+#' bizdays(x, FinCenter = "New York")
 #' @export
 bizdays <- function(x, FinCenter = c(
-                    "New York", "London", "NERC", "Tokyo",
-                    "Zurich"
-                  )) {
+                      "New York", "London", "NERC", "Tokyo",
+                      "Zurich"
+                    )) {
   # Return the number of trading days corresponding to the input ts
   #
   # Args:
@@ -104,8 +103,7 @@ bizdays <- function(x, FinCenter = c(
 #' @keywords ts
 #' @examples
 #'
-#'   easter(wineind, easter.mon = TRUE)
-#'
+#' easter(wineind, easter.mon = TRUE)
 #' @export
 easter <- function(x, easter.mon = FALSE) {
   # Return a vector of 0's and 1's for easter holidays

--- a/R/errors.R
+++ b/R/errors.R
@@ -284,8 +284,8 @@ accuracy.default <- function(object, x, test=NULL, d=NULL, D=NULL, f = NULL, ...
         D <- as.numeric(frequency(object$mean) > 1)
       }
       else {
-        d <- as.numeric(frequency(object$x) == 1)
-        D <- as.numeric(frequency(object$x) > 1)
+        d <- as.numeric(frequency(object[["x"]]) == 1)
+        D <- as.numeric(frequency(object[["x"]]) > 1)
       }
     }
     else {

--- a/R/errors.R
+++ b/R/errors.R
@@ -53,7 +53,7 @@ testaccuracy <- function(f, x, test, d, D) {
   pe <- error / xx[test] * 100
 
   me <- mean(error, na.rm = TRUE)
-  mse <- mean(error ^ 2, na.rm = TRUE)
+  mse <- mean(error^2, na.rm = TRUE)
   mae <- mean(abs(error), na.rm = TRUE)
   mape <- mean(abs(pe), na.rm = TRUE)
   mpe <- mean(pe, na.rm = TRUE)
@@ -87,7 +87,7 @@ testaccuracy <- function(f, x, test, d, D) {
   if (!is.null(tsp(x)) && n > 1) {
     fpe <- (c(ff[2:n]) / c(xx[1:(n - 1)]) - 1)[test - 1]
     ape <- (c(xx[2:n]) / c(xx[1:(n - 1)]) - 1)[test - 1]
-    theil <- sqrt(sum((fpe - ape) ^ 2, na.rm = TRUE) / sum(ape ^ 2, na.rm = TRUE))
+    theil <- sqrt(sum((fpe - ape)^2, na.rm = TRUE) / sum(ape^2, na.rm = TRUE))
     if (length(error) > 1) {
       r1 <- acf(error, plot = FALSE, lag.max = 2, na.action = na.pass)$acf[2, 1, 1]
     } else {
@@ -130,7 +130,7 @@ trainingaccuracy <- function(f, test, d, D) {
   pe <- res / dx * 100 # Percentage error
 
   me <- mean(res, na.rm = TRUE)
-  mse <- mean(res ^ 2, na.rm = TRUE)
+  mse <- mean(res^2, na.rm = TRUE)
   mae <- mean(abs(res), na.rm = TRUE)
   mape <- mean(abs(pe), na.rm = TRUE)
   mpe <- mean(pe, na.rm = TRUE)
@@ -232,14 +232,14 @@ trainingaccuracy <- function(f, test, d, D) {
 #' @keywords ts
 #' @examples
 #'
-#' fit1 <- rwf(EuStockMarkets[1:200,1],h=100)
-#' fit2 <- meanf(EuStockMarkets[1:200,1],h=100)
+#' fit1 <- rwf(EuStockMarkets[1:200, 1], h = 100)
+#' fit2 <- meanf(EuStockMarkets[1:200, 1], h = 100)
 #' accuracy(fit1)
 #' accuracy(fit2)
-#' accuracy(fit1,EuStockMarkets[201:300,1])
-#' accuracy(fit2,EuStockMarkets[201:300,1])
+#' accuracy(fit1, EuStockMarkets[201:300, 1])
+#' accuracy(fit2, EuStockMarkets[201:300, 1])
 #' plot(fit1)
-#' lines(EuStockMarkets[1:300,1])
+#' lines(EuStockMarkets[1:300, 1])
 #' @export
 accuracy <- function(object, ...) {
   UseMethod("accuracy")
@@ -248,8 +248,8 @@ accuracy <- function(object, ...) {
 #' @rdname accuracy
 #' @method accuracy default
 #' @export
-accuracy.default <- function(object, x, test=NULL, d=NULL, D=NULL, f = NULL, ...) {
-  if(!is.null(f)){
+accuracy.default <- function(object, x, test = NULL, d = NULL, D = NULL, f = NULL, ...) {
+  if (!is.null(f)) {
     warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
     object <- f
   }
@@ -332,8 +332,8 @@ accuracy.default <- function(object, x, test=NULL, d=NULL, D=NULL, f = NULL, ...
 
 # Compute accuracy for an mforecast object
 #' @export
-accuracy.mforecast <- function(object, x, test=NULL, d, D, f = NULL, ...) {
-  if(!is.null(f)){
+accuracy.mforecast <- function(object, x, test = NULL, d, D, f = NULL, ...) {
+  if (!is.null(f)) {
     warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
     object <- f
   }

--- a/R/etsforecast.R
+++ b/R/etsforecast.R
@@ -174,7 +174,7 @@ pegelsfcast.C <- function(h, obj, npaths, level, bootstrap) {
     y.paths[i, ] <- simulate.ets(obj, h, future = TRUE, bootstrap = bootstrap)
   y.f <- .C(
     "etsforecast",
-    as.double(obj$state[length(obj$x) + 1, ]),
+    as.double(obj$states[length(obj$x) + 1, ]),
     as.integer(obj$m),
     as.integer(switch(obj$components[2], "N" = 0, "A" = 1, "M" = 2)),
     as.integer(switch(obj$components[3], "N" = 0, "A" = 1, "M" = 2)),

--- a/R/forecastTBATS.R
+++ b/R/forecastTBATS.R
@@ -52,7 +52,7 @@ forecast.tbats <- function(object, h, level=c(80, 95), fan=FALSE, biasadj=NULL, 
 
   if (!is.null(object$seasonal.periods)) {
     gamma.bold <- matrix(0, nrow = 1, ncol = tau)
-    .Call("updateTBATSGammaBold", gammaBold_s = gamma.bold, kVector_s = as.integer(object$k.vector), gammaOne_s = object$gamma.one.v, gammaTwo_s = object$gamma.two.v, PACKAGE = "forecast")
+    .Call("updateTBATSGammaBold", gammaBold_s = gamma.bold, kVector_s = as.integer(object$k.vector), gammaOne_s = object$gamma.one.values, gammaTwo_s = object$gamma.two.values, PACKAGE = "forecast")
   } else {
     gamma.bold <- NULL
   }

--- a/R/forecastTBATS.R
+++ b/R/forecastTBATS.R
@@ -1,6 +1,6 @@
 #' @rdname forecast.bats
 #' @export
-forecast.tbats <- function(object, h, level=c(80, 95), fan=FALSE, biasadj=NULL, ...) {
+forecast.tbats <- function(object, h, level = c(80, 95), fan = FALSE, biasadj = NULL, ...) {
   # Check if forecast.tbats called incorrectly
   if (identical(class(object), "bats")) {
     return(forecast.bats(object, h, level, fan, biasadj, ...))
@@ -91,7 +91,7 @@ forecast.tbats <- function(object, h, level=c(80, 95), fan=FALSE, biasadj=NULL, 
         f.running <- f.running %*% F
       }
       c.j <- w$w.transpose %*% f.running %*% g
-      variance.multiplier[(j + 1)] <- variance.multiplier[j] + c.j ^ 2
+      variance.multiplier[(j + 1)] <- variance.multiplier[j] + c.j^2
     }
   }
 

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -2351,7 +2351,7 @@ gghistogram <- function(x, add.normal=FALSE, add.kde=FALSE, add.rug=TRUE, bins, 
         xmin <- min(xmin, xmean - 3 * xsd)
         xmax <- max(xmax, xmean + 3 * xsd)
       }
-      xgrid <- seq(xmin, xmax, l = 512)
+      xgrid <- seq(xmin, xmax, length.out = 512)
       if (add.normal) {
         df <- data.frame(x = xgrid, y = length(x) * binwidth * stats::dnorm(xgrid, xmean, xsd))
         p <- p + ggplot2::geom_line(ggplot2::aes(df$x, df$y), col = "#ff8a62")

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -78,7 +78,7 @@ simulate.ets <- function(object, nsim=length(object$x), seed=NULL, future=TRUE, 
     e <- sample(res, nsim, replace = TRUE)
   }
   else if (is.null(innov)) {
-    e <- rnorm(nsim, 0, sqrt(object$sigma))
+    e <- rnorm(nsim, 0, sqrt(object$sigma2))
   } else if (length(innov) == nsim) {
     e <- innov
   } else {

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -68,9 +68,9 @@ simulate.ets <- function(object, nsim=length(object$x), seed=NULL, future=TRUE, 
   }
 
   if (future) {
-    initstate <- object$state[length(object$x) + 1, ]
+    initstate <- object$states[length(object$x) + 1, ]
   } else { # choose a random starting point
-    initstate <- object$state[sample(1:length(object$x), 1), ]
+    initstate <- object$states[sample(1:length(object$x), 1), ]
   }
 
   if (bootstrap) {

--- a/R/theta.R
+++ b/R/theta.R
@@ -60,10 +60,9 @@
 #' @examples
 #' nile.fcast <- thetaf(Nile)
 #' plot(nile.fcast)
-#'
 #' @export
-thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
-                   level=c(80, 95), fan=FALSE, x=y) {
+thetaf <- function(y, h = ifelse(frequency(y) > 1, 2 * frequency(y), 10),
+                   level = c(80, 95), fan = FALSE, x = y) {
   # Check inputs
   if (fan) {
     level <- seq(51, 99, by = 3)
@@ -79,9 +78,9 @@ thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   n <- length(x)
   x <- as.ts(x)
   m <- frequency(x)
-  if (m > 1 && !is.constant(x) && n > 2*m) {
+  if (m > 1 && !is.constant(x) && n > 2 * m) {
     r <- as.numeric(acf(x, lag.max = m, plot = FALSE)$acf)[-1]
-    stat <- sqrt((1 + 2 * sum(r[-m] ^ 2)) / n)
+    stat <- sqrt((1 + 2 * sum(r[-m]^2)) / n)
     seasonal <- (abs(r[m]) / stat > qnorm(0.95))
   }
   else {
@@ -92,27 +91,28 @@ thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   origx <- x
   if (seasonal) {
     decomp <- decompose(x, type = "multiplicative")
-    if(any(abs(seasonal(decomp)) < 1e-10))
+    if (any(abs(seasonal(decomp)) < 1e-10)) {
       warning("Seasonal indexes equal to zero. Using non-seasonal Theta method")
-    else
+    } else {
       x <- seasadj(decomp)
+    }
   }
 
   # Find theta lines
   fcast <- ses(x, h = h)
   tmp2 <- lsfit(0:(n - 1), x)$coefficients[2] / 2
-  alpha <- pmax(1e-10,fcast$model$par["alpha"])
-  fcast$mean <- fcast$mean + tmp2 * (0:(h - 1) + (1 - (1 - alpha) ^ n) / alpha)
+  alpha <- pmax(1e-10, fcast$model$par["alpha"])
+  fcast$mean <- fcast$mean + tmp2 * (0:(h - 1) + (1 - (1 - alpha)^n) / alpha)
 
   # Reseasonalize
   if (seasonal) {
     fcast$mean <- fcast$mean * rep(tail(decomp$seasonal, m), trunc(1 + h / m))[1:h]
     fcast$fitted <- fcast$fitted * decomp$seasonal
   }
-  fcast$residuals <- origx-fcast$fitted
+  fcast$residuals <- origx - fcast$fitted
 
   # Find prediction intervals
-  fcast.se <- sqrt(fcast$model$sigma) * sqrt((0:(h - 1)) * alpha ^ 2 + 1)
+  fcast.se <- sqrt(fcast$model$sigma) * sqrt((0:(h - 1)) * alpha^2 + 1)
   nconf <- length(level)
   fcast$lower <- fcast$upper <- ts(matrix(NA, nrow = h, ncol = nconf))
   tsp(fcast$lower) <- tsp(fcast$upper) <- tsp(fcast$mean)

--- a/R/theta.R
+++ b/R/theta.R
@@ -112,7 +112,7 @@ thetaf <- function(y, h = ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   fcast$residuals <- origx - fcast$fitted
 
   # Find prediction intervals
-  fcast.se <- sqrt(fcast$model$sigma) * sqrt((0:(h - 1)) * alpha^2 + 1)
+  fcast.se <- sqrt(fcast$model$sigma2) * sqrt((0:(h - 1)) * alpha^2 + 1)
   nconf <- length(level)
   fcast$lower <- fcast$upper <- ts(matrix(NA, nrow = h, ncol = nconf))
   tsp(fcast$lower) <- tsp(fcast$upper) <- tsp(fcast$mean)
@@ -127,7 +127,7 @@ thetaf <- function(y, h = ifelse(frequency(y) > 1, 2 * frequency(y), 10),
   fcast$x <- origx
   fcast$level <- level
   fcast$method <- "Theta"
-  fcast$model <- list(alpha = alpha, drift = tmp2, sigma = fcast$model$sigma)
+  fcast$model <- list(alpha = alpha, drift = tmp2, sigma = fcast$model$sigma2)
   fcast$model$call <- match.call()
   return(fcast)
 }

--- a/R/theta.R
+++ b/R/theta.R
@@ -100,7 +100,7 @@ thetaf <- function(y, h=ifelse(frequency(y) > 1, 2 * frequency(y), 10),
 
   # Find theta lines
   fcast <- ses(x, h = h)
-  tmp2 <- lsfit(0:(n - 1), x)$coef[2] / 2
+  tmp2 <- lsfit(0:(n - 1), x)$coefficients[2] / 2
   alpha <- pmax(1e-10,fcast$model$par["alpha"])
   fcast$mean <- fcast$mean + tmp2 * (0:(h - 1) + (1 - (1 - alpha) ^ n) / alpha)
 

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -6,7 +6,7 @@ if (require(testthat)) {
     # Test for identical on series without NAs
     expect_true(all(na.interp(wineind) == wineind))
     # Test seasonal interpolation
-    testseries <- ts(rep(1:7, 5), f = 7)
+    testseries <- ts(rep(1:7, 5), frequency = 7)
     testseries[c(1, 3, 11, 17)] <- NA
     expect_true(sum(abs(na.interp(testseries) - rep(1:7, 5))) < 1e-14)
     # Test length of output
@@ -16,7 +16,7 @@ if (require(testthat)) {
     # Test for no NAs
     expect_false(any(is.na(tsclean(gold))))
     # Test for removing outliers in seasonal series
-    testseries <- ts(rep(1:7, 5), f = 7)
+    testseries <- ts(rep(1:7, 5), frequency = 7)
     testseries[c(2, 4, 14)] <- 0
     expect_true(sum(abs(tsclean(testseries) - rep(1:7, 5))) < 1e-14)
     # Test for NAs left with replace.missing = FALSE argument

--- a/tests/testthat/test-forecast2.R
+++ b/tests/testthat/test-forecast2.R
@@ -10,7 +10,7 @@ if (require(testthat)) {
     expect_error(meanf(wineind, level = -10))
     expect_error(meanf(wineind, level = 110))
     # Constant series should not error
-    series <- ts(rep(950, 20), f = 4)
+    series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(rwf(series), NA)
     expect_true(is.constant(constantForecast$mean))
   })
@@ -23,7 +23,7 @@ if (require(testthat)) {
     expect_true(length(rwf(airmiles, lambda = 0.15)$mean) == 10)
     expect_false(identical(rwf(airmiles, lambda = 0.15, biasadj = FALSE)$mean, rwf(airmiles, lambda = 0.15, biasadj = TRUE)$mean))
     # Constant series should not error
-    series <- ts(rep(950, 20), f = 4)
+    series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(rwf(series), NA)
     expect_true(is.constant(constantForecast$mean))
   })
@@ -80,7 +80,7 @@ if (require(testthat)) {
     expect_true(all(snaive(WWWusage, h = 10)$upper == naive(WWWusage)$upper))
     expect_true(all(snaive(WWWusage, h = 10)$lower == naive(WWWusage)$lower))
     # Constant series should not error
-    series <- ts(rep(950, 20), f = 4)
+    series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(snaive(series), NA)
     expect_true(is.constant(constantForecast$mean))
   })

--- a/tests/testthat/test-ggplot.R
+++ b/tests/testthat/test-ggplot.R
@@ -68,7 +68,7 @@ if (require(testthat)) {
 
     autoplot(USAccDeaths)
     autoplot(lungDeaths)
-    autoplot(lungDeaths, facet = TRUE)
+    autoplot(lungDeaths, facets = TRUE)
 
     autoplot(USAccDeaths) + geom_forecast()
     autoplot(USAccDeaths) + autolayer(etsfcast, series = "ETS")
@@ -76,7 +76,7 @@ if (require(testthat)) {
     autoplot(lungDeaths) + autolayer(mfcast, series = c("mdeaths", "fdeaths"))
     autoplot(lungDeaths) + autolayer(mfcast)
     autoplot(lungDeaths) + autolayer(mfcast, series = TRUE)
-    autoplot(lungDeaths, facet = TRUE) + geom_forecast()
+    autoplot(lungDeaths, facets = TRUE) + geom_forecast()
 
     gghistogram(USAccDeaths, add.kde = TRUE)
   })

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -3,7 +3,7 @@ if (require(testthat)) {
   context("Testing graph")
   test_that("Tests for seasonplot()", {
     expect_error(seasonplot(airmiles))
-    seasonplot(ts(gold, f = 7))
+    seasonplot(ts(gold, frequency = 7))
     seasonplot(woolyrnq)
     seasonplot(wineind)
     seasonplot(wineind, year.labels = TRUE)

--- a/tests/testthat/test-modelAR.R
+++ b/tests/testthat/test-modelAR.R
@@ -76,16 +76,14 @@ if (require(testthat)) {
     expect_true(length(forecast(woolyrnqnnet, xreg = 120:130)$mean) == 11)
     expect_true(identical(forecast(woolyrnqnnet, xreg = 120:130)$mean, forecast(woolyrnqnnet2, xreg = 120:130)$mean))
     ## Test with multiple-column xreg
-    expect_silent({
-      set.seed(123)
-      winennet <- modelAR(wineind, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = cbind(bizdays(wineind), fourier(wineind, 1)), p = 2, P = 1, size = 4, repeats = 10)
-      set.seed(123)
-      winennet2 <- nnetar(
-        wineind,
-        xreg = cbind(bizdays(wineind), fourier(wineind, 1)),
-        p = 2, P = 1, size = 4, repeats = 10
-      )
-    })
+    set.seed(123)
+    winennet <- modelAR(wineind, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = cbind(bizdays(wineind), fourier(wineind, 1)), p = 2, P = 1, size = 4, repeats = 10)
+    set.seed(123)
+    winennet2 <- nnetar(
+      wineind,
+      xreg = cbind(bizdays(wineind), fourier(wineind, 1)),
+      p = 2, P = 1, size = 4, repeats = 10
+    )
     expect_true(length(forecast(winennet, h = 2, xreg = matrix(2, 2, 3))$mean) == 2L)
     ## Test if h matches xreg
     expect_true(length(forecast(winennet, h = 5, xreg = matrix(2, 2, 3))$mean) == 2L)

--- a/tests/testthat/test-modelAR.R
+++ b/tests/testthat/test-modelAR.R
@@ -3,42 +3,43 @@ if (require(testthat)) {
   context("Testing modelAR")
   test_that("Tests for modelAR", {
     ## Set up functions to match 'nnetar' behavior
-    avnnet2 <- function(x, y, repeats = repeats, linout=TRUE, trace=FALSE, ...){
+    avnnet2 <- function(x, y, repeats = repeats, linout = TRUE, trace = FALSE, ...) {
       mods <- list()
-      for (i in 1:repeats)
+      for (i in 1:repeats) {
         mods[[i]] <- nnet::nnet(x, y, linout = linout, trace = trace, ...)
+      }
       return(structure(mods, class = "nnetarmodels"))
     }
     ##
-    predict.avnnet2 <- function(model, newdata=NULL){
-      if (is.null(newdata)){
+    predict.avnnet2 <- function(model, newdata = NULL) {
+      if (is.null(newdata)) {
         if (length(predict(model[[1]])) > 1) {
           rowMeans(sapply(model, predict))
         } else {
           mean(sapply(model, predict))
         }
       } else {
-        if (NCOL(newdata) >= 2 & NROW(newdata) >= 2){
-          rowMeans(sapply(model, predict, newdata=newdata))
+        if (NCOL(newdata) >= 2 & NROW(newdata) >= 2) {
+          rowMeans(sapply(model, predict, newdata = newdata))
         } else {
-          mean(sapply(model, predict, newdata=newdata))
+          mean(sapply(model, predict, newdata = newdata))
         }
       }
     }
     ## compare residuals to 'nnetar'
     expect_silent({
       set.seed(123)
-      nnetar_model <- nnetar(lynx[1:100], p=2, P=1, size=3, repeats=20)
+      nnetar_model <- nnetar(lynx[1:100], p = 2, P = 1, size = 3, repeats = 20)
       set.seed(123)
-      modelAR_model <- modelAR(lynx[1:100], FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=1, scale.inputs = TRUE, size=3, repeats=20)
+      modelAR_model <- modelAR(lynx[1:100], FUN = avnnet2, predict.FUN = predict.avnnet2, p = 2, P = 1, scale.inputs = TRUE, size = 3, repeats = 20)
       res1 <- residuals(nnetar_model)
       res2 <- residuals(modelAR_model)
     })
     expect_true(identical(res1, res2))
     ## check re-fitting old model and compare to 'nnetar'
     expect_silent({
-      nnetar_model2 <- nnetar(lynx[101:114], model=nnetar_model)
-      modelAR_model2 <- modelAR(lynx[101:114], FUN = avnnet2, predict.FUN= predict.avnnet2, model=modelAR_model)
+      nnetar_model2 <- nnetar(lynx[101:114], model = nnetar_model)
+      modelAR_model2 <- modelAR(lynx[101:114], FUN = avnnet2, predict.FUN = predict.avnnet2, model = modelAR_model)
       res1 <- residuals(nnetar_model2)
       res2 <- residuals(modelAR_model2)
     })
@@ -52,9 +53,9 @@ if (require(testthat)) {
     ## test lambda and compare to 'nnetar'
     expect_silent({
       set.seed(123)
-      oilnnet_nnetar  <- nnetar(airmiles, lambda = 0.15, size = 1, repeats=20)
+      oilnnet_nnetar <- nnetar(airmiles, lambda = 0.15, size = 1, repeats = 20)
       set.seed(123)
-      oilnnet_modelAR  <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, lambda = 0.15, size = 1, repeats=20)
+      oilnnet_modelAR <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, lambda = 0.15, size = 1, repeats = 20)
     })
     expect_true(identical(residuals(oilnnet_nnetar, type = "response"), residuals(oilnnet_modelAR, type = "response")))
     expect_true(length(forecast(oilnnet_modelAR)$mean) == 10)
@@ -77,18 +78,18 @@ if (require(testthat)) {
     ## Test with multiple-column xreg
     expect_silent({
       set.seed(123)
-      winennet <- modelAR(wineind, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE,  xreg = cbind(bizdays(wineind), fourier(wineind, 1)), p = 2, P = 1, size = 4, repeats = 10)
+      winennet <- modelAR(wineind, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = cbind(bizdays(wineind), fourier(wineind, 1)), p = 2, P = 1, size = 4, repeats = 10)
       set.seed(123)
       winennet2 <- nnetar(
-          wineind,
-          xreg = cbind(bizdays(wineind), fourier(wineind, 1)),
-          p = 2, P=1, size = 4, repeats = 10
-          )
+        wineind,
+        xreg = cbind(bizdays(wineind), fourier(wineind, 1)),
+        p = 2, P = 1, size = 4, repeats = 10
+      )
     })
     expect_true(length(forecast(winennet, h = 2, xreg = matrix(2, 2, 3))$mean) == 2L)
     ## Test if h matches xreg
     expect_true(length(forecast(winennet, h = 5, xreg = matrix(2, 2, 3))$mean) == 2L)
-    expect_warning(forecast(winennet2, xreg = matrix(2, 2, 3))$mean, "different column names") %>% 
+    expect_warning(forecast(winennet2, xreg = matrix(2, 2, 3))$mean, "different column names") %>%
       expect_identical(forecast(winennet, xreg = matrix(2, 2, 3))$mean)
     ## Test that P is ignored if m=1
     expect_warning(wwwnnet <- modelAR(WWWusage, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, xreg = 1:length(WWWusage), p = 2, P = 4, size = 3, repeats = 10))
@@ -99,9 +100,10 @@ if (require(testthat)) {
       set.seed(123)
       wwwnnet2 <- nnetar(WWWusage, size = 3, p = 2, P = 0, xreg = 1:length(WWWusage), decay = 0.1, repeats = 10)
     })
-    expect_true(identical(forecast(wwwnnet, h=2, xreg = (length(WWWusage)+1):(length(WWWusage)+5))$mean,
-              forecast(wwwnnet2, h=2, xreg = (length(WWWusage)+1):(length(WWWusage)+5))$mean
-              ))
+    expect_true(identical(
+      forecast(wwwnnet, h = 2, xreg = (length(WWWusage) + 1):(length(WWWusage) + 5))$mean,
+      forecast(wwwnnet2, h = 2, xreg = (length(WWWusage) + 1):(length(WWWusage) + 5))$mean
+    ))
     ## Test output format correct when NAs present
     airna <- airmiles
     airna[12] <- NA
@@ -111,13 +113,14 @@ if (require(testthat)) {
     expect_silent({
       set.seed(123)
       fit1 <- modelAR(
-          WWWusage, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE,
-          xreg = 1:length(WWWusage),
-          p = 3, size=2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7
-          )
+        WWWusage,
+        FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE,
+        xreg = 1:length(WWWusage),
+        p = 3, size = 2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7
+      )
       fit2 <- modelAR(WWWusage, xreg = 1:length(WWWusage), model = fit1)
       set.seed(123)
-      fit3 <- nnetar(WWWusage, xreg = 1:length(WWWusage), p = 3, size=2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7)
+      fit3 <- nnetar(WWWusage, xreg = 1:length(WWWusage), p = 3, size = 2, lambda = 2, decay = 0.5, maxit = 25, repeats = 7)
     })
     # Check some model parameters
     expect_true(identical(fit1$p, fit2$p))
@@ -125,7 +128,7 @@ if (require(testthat)) {
     expect_true(identical(fit1$modelargs, fit2$modelargs))
     # Check fitted values are all the same
     expect_true(identical(fitted(fit1), fitted(fit2)))
-    expect_true(identical(fitted(fit1, h=2), fitted(fit2, h=2)))
+    expect_true(identical(fitted(fit1, h = 2), fitted(fit2, h = 2)))
     # Check residuals all the same
     expect_true(identical(residuals(fit1), residuals(fit2)))
     # Check number of neural nets
@@ -135,54 +138,54 @@ if (require(testthat)) {
     expect_true(identical(fit1$model[[7]]$wts, fit2$model[[7]]$wts))
     ## compare results with 'nnetar'
     expect_true(identical(fitted(fit1), fitted(fit3)))
-    expect_true(identical(fitted(fit1, h=3), fitted(fit3, h=3)))
-    expect_true(identical(residuals(fit1, type="response"), residuals(fit3, type="response")))
+    expect_true(identical(fitted(fit1, h = 3), fitted(fit3, h = 3)))
+    expect_true(identical(residuals(fit1, type = "response"), residuals(fit3, type = "response")))
     ## Check subset argument using indices
     expect_silent({
       set.seed(123)
-      airnnet <- modelAR(airmiles, , FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = 11:20, p=1, size=1, repeats=10)
+      airnnet <- modelAR(airmiles, , FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = 11:20, p = 1, size = 1, repeats = 10)
       set.seed(123)
-      airnnet2 <- nnetar(airmiles, , subset = 11:20, p=1, size=1, repeats=10)
+      airnnet2 <- nnetar(airmiles, , subset = 11:20, p = 1, size = 1, repeats = 10)
     })
     expect_true(identical(which(!is.na(fitted(airnnet))), 11:20))
     expect_true(identical(fitted(airnnet), fitted(airnnet2)))
-    expect_true(identical(forecast(airnnet, h=5)$mean, forecast(airnnet2, h=5)$mean))
+    expect_true(identical(forecast(airnnet, h = 5)$mean, forecast(airnnet2, h = 5)$mean))
     ## Check subset argument using logical vector
     expect_silent({
       set.seed(123)
-      airnnet <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p=1, size=1, repeats=10)
+      airnnet <- modelAR(airmiles, FUN = avnnet2, predict.FUN = predict.avnnet2, scale.inputs = TRUE, subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p = 1, size = 1, repeats = 10)
       set.seed(123)
-      airnnet2 <- nnetar(airmiles, , subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p=1, size=1, repeats=10)
+      airnnet2 <- nnetar(airmiles, , subset = c(rep(F, 10), rep(T, 10), rep(F, length(airmiles) - 20)), p = 1, size = 1, repeats = 10)
     })
     expect_true(identical(which(!is.na(fitted(airnnet))), 11:20))
     expect_true(identical(fitted(airnnet), fitted(airnnet2)))
-    expect_true(identical(forecast(airnnet, h=5)$mean, forecast(airnnet2, h=5)$mean))
+    expect_true(identical(forecast(airnnet, h = 5)$mean, forecast(airnnet2, h = 5)$mean))
     ## compare prediction intervals with 'nnetar'
     expect_silent({
       set.seed(456)
-      f1 <- forecast(airnnet, h=5, PI=TRUE, npaths=100)
+      f1 <- forecast(airnnet, h = 5, PI = TRUE, npaths = 100)
       set.seed(456)
-      f2 <- forecast(airnnet2, h=5, PI=TRUE, npaths=100)
+      f2 <- forecast(airnnet2, h = 5, PI = TRUE, npaths = 100)
     })
     expect_true(identical(f1$upper, f2$upper))
     expect_true(identical(f1$lower, f2$lower))
     ## Check short and constant data
-    expect_warning(nnetfit <- modelAR(rep(1, 10), FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant data")
+    expect_warning(nnetfit <- modelAR(rep(1, 10), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 2, P = 0, size = 1, repeats = 1, lambda = 0.1), "Constant data")
     expect_true(nnetfit$p == 1)
     expect_true(is.null(nnetfit$lambda))
     expect_true(is.null(nnetfit$scalex))
-    expect_error(nnetfit <- modelAR(rnorm(2), FUN = avnnet2, predict.FUN = predict.avnnet2, p=1, P=0, size=1, repeats=1), "Not enough data")
-    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=1, P=0, size=1, repeats=1))
+    expect_error(nnetfit <- modelAR(rnorm(2), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 1, P = 0, size = 1, repeats = 1), "Not enough data")
+    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 1, P = 0, size = 1, repeats = 1))
     expect_true(nnetfit$p == 1)
-    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=2, P=0, size=1, repeats=1))
+    expect_silent(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 2, P = 0, size = 1, repeats = 1))
     expect_true(nnetfit$p == 2)
-    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=3, P=0, size=1, repeats=1), "short series")
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 3, P = 0, size = 1, repeats = 1), "short series")
     expect_true(nnetfit$p == 2)
-    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p=4, P=0, size=1, repeats=1), "short series")
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, p = 4, P = 0, size = 1, repeats = 1), "short series")
     expect_true(nnetfit$p == 2)
-    expect_warning(nnetfit <- modelAR(rnorm(10), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg=rep(1, 10), p=2, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_warning(nnetfit <- modelAR(rnorm(10), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg = rep(1, 10), p = 2, P = 0, size = 1, repeats = 1, lambda = 0.1), "Constant xreg")
     expect_true(is.null(nnetfit$scalexreg))
-    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg=matrix(c(1, 2, 3, 1, 1, 1), ncol=2), p=1, P=0, size=1, repeats=1, lambda = 0.1), "Constant xreg")
+    expect_warning(nnetfit <- modelAR(rnorm(3), FUN = avnnet2, predict.FUN = predict.avnnet2, xreg = matrix(c(1, 2, 3, 1, 1, 1), ncol = 2), p = 1, P = 0, size = 1, repeats = 1, lambda = 0.1), "Constant xreg")
     expect_true(is.null(nnetfit$scalexreg))
   })
 }

--- a/tests/testthat/test-newarima2.R
+++ b/tests/testthat/test-newarima2.R
@@ -26,13 +26,13 @@ if (require(testthat)) {
     expect_equal(auto.arima(WWWusage, parallel = TRUE, stepwise = FALSE)$arma, c(3L, 0L, 0L, 0L, 1L, 1L, 0L))
   })
 
-  
+
   test_that("tests for ndiffs()", {
     expect_true(ndiffs(AirPassengers, test = "kpss") == 1)
     expect_true(ndiffs(AirPassengers, test = "adf") == 1)
     expect_true(ndiffs(AirPassengers, test = "pp") == 1)
   })
-  
+
   test_that("tests for nsdiffs()", {
     expect_true(nsdiffs(AirPassengers, test = "seas") == 1)
     expect_true(nsdiffs(AirPassengers, test = "ocsb") == 1)

--- a/tests/testthat/test-newarima2.R
+++ b/tests/testthat/test-newarima2.R
@@ -3,18 +3,18 @@ if (require(testthat)) {
   test_that("test auto.arima() and associated methods", {
     expect_warning(auto.arima(rep(1, 100), stepwise = TRUE, parallel = TRUE))
     set.seed(345)
-    testseries1 <- ts(rnorm(100) + 1:100, f = 0.1)
+    testseries1 <- ts(rnorm(100) + 1:100, frequency = 0.1)
     xregmat <- matrix(runif(300), ncol = 3)
     expect_true(frequency(forecast(auto.arima(testseries1))) == 1)
     fit1 <- auto.arima(testseries1, xreg = xregmat, allowdrift = FALSE)
     expect_true(all(xregmat == fit1$xreg))
 
-    testseries2 <- ts(rep(100, 120), f = 12)
+    testseries2 <- ts(rep(100, 120), frequency = 12)
     xregmat <- matrix(runif(240), ncol = 2)
     expect_output(print(auto.arima(testseries2, xreg = xregmat)), regexp = "Series: testseries2")
 
     expect_output(summary(auto.arima(testseries2, xreg = xregmat, approximation = TRUE, stepwise = FALSE)), regexp = "Series: testseries2")
-    expect_output(print(auto.arima(ts(testseries2, f = 4), approximation = TRUE, trace = TRUE)), regexp = "ARIMA")
+    expect_output(print(auto.arima(ts(testseries2, frequency = 4), approximation = TRUE, trace = TRUE)), regexp = "ARIMA")
 
     fit1 <- auto.arima(testseries1, stepwise = FALSE, lambda = 2, biasadj = FALSE)
     fit2 <- auto.arima(testseries1, stepwise = FALSE, lambda = 2, biasadj = TRUE)
@@ -38,7 +38,7 @@ if (require(testthat)) {
     expect_true(nsdiffs(AirPassengers, test = "ocsb") == 1)
     expect_error(nsdiffs(airmiles))
     expect_true(nsdiffs(rep(1, 100)) == 0)
-    expect_warning(nsdiffs(ts(rnorm(10), f = 0.1)))
+    expect_warning(nsdiffs(ts(rnorm(10), frequency = 0.1)))
     skip_if_not_installed("uroot")
     expect_true(nsdiffs(AirPassengers, test = "hegy") == 1)
     expect_true(nsdiffs(AirPassengers, test = "ch") == 0)

--- a/tests/testthat/test-refit.R
+++ b/tests/testthat/test-refit.R
@@ -90,7 +90,7 @@ if (require(testthat)) {
     refit_same <- bats(mdeaths, model = fit)
     expect_true(identical(fit$model$par, refit_same$model$par))
     expect_true(identical(fit$x, refit_same$x))
-    expect_true(identical(fit$fitted, refit_same$fitted))
+    expect_true(identical(fit$fitted.values, refit_same$fitted.values))
     expect_true(identical(residuals(fit), residuals(refit_same)))
 
     # tbats
@@ -105,7 +105,7 @@ if (require(testthat)) {
     refit_same <- tbats(mdeaths, model = fit)
     expect_true(identical(fit$model$par, refit_same$model$par))
     expect_true(identical(fit$x, refit_same$x))
-    expect_true(identical(fit$fitted, refit_same$fitted))
+    expect_true(identical(fit$fitted.values, refit_same$fitted.values))
     expect_true(identical(residuals(fit), residuals(refit_same)))
 
     # nnetar

--- a/tests/testthat/test-season.R
+++ b/tests/testthat/test-season.R
@@ -67,7 +67,7 @@ if (require(testthat)) {
     series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(stlf(series), NA)
     # Small eps
-    expect_true(all(abs(constantForecast$mean - mean(series)) < 10 ^ -8))
+    expect_true(all(abs(constantForecast$mean - mean(series)) < 10^-8))
 
     y <- ts(rep(1:7, 3), frequency = 7)
     expect_equal(c(stlf(y)$mean), rep(1:7, 2))

--- a/tests/testthat/test-season.R
+++ b/tests/testthat/test-season.R
@@ -3,16 +3,16 @@ if (require(testthat)) {
   test_that("tests for monthdays", {
     expect_error(monthdays(rnorm(10)))
     expect_error(monthdays(rnorm(10)))
-    expect_true(all(monthdays(ts(rep(100, 12), f = 12)) == c(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)))
-    expect_true(all(monthdays(ts(rep(1, 4), f = 4)) == c(90, 91, 92, 92)))
+    expect_true(all(monthdays(ts(rep(100, 12), frequency = 12)) == c(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)))
+    expect_true(all(monthdays(ts(rep(1, 4), frequency = 4)) == c(90, 91, 92, 92)))
     # Test leapyears
-    expect_true(monthdays(ts(rep(1, 48), f = 12))[38] == 29)
-    expect_true(monthdays(ts(rep(1, 16), f = 4))[13] == 91)
+    expect_true(monthdays(ts(rep(1, 48), frequency = 12))[38] == 29)
+    expect_true(monthdays(ts(rep(1, 16), frequency = 4))[13] == 91)
   })
 
   test_that("tests for seasonaldummy", {
     expect_error(seasonaldummy(1))
-    testseries <- ts(rep(1:7, 5), f = 7)
+    testseries <- ts(rep(1:7, 5), frequency = 7)
     dummymat <- seasonaldummy(testseries)
     expect_true(length(testseries) == nrow(dummymat))
     expect_true(ncol(dummymat) == 6)
@@ -28,7 +28,7 @@ if (require(testthat)) {
 
   test_that("tests for fourier", {
     expect_error(fourier(1))
-    testseries <- ts(rep(1:7, 5), f = 7)
+    testseries <- ts(rep(1:7, 5), frequency = 7)
     fouriermat <- fourier(testseries, 3)
     expect_true(length(testseries) == nrow(fouriermat))
     expect_true(ncol(fouriermat) == 6)
@@ -42,7 +42,7 @@ if (require(testthat)) {
   })
 
   test_that("tests for stlm", {
-    expect_warning(stlm(ts(rep(5, 24), f = 4), etsmodel = "ZZZ"))
+    expect_warning(stlm(ts(rep(5, 24), frequency = 4), etsmodel = "ZZZ"))
   })
 
   test_that("tests for forecast.stlm", {
@@ -53,8 +53,8 @@ if (require(testthat)) {
     fcfit2 <- forecast(stlmfit1, fan = TRUE)
     expect_true(all(fcfit2$level == seq(from = 51, to = 99, by = 3)))
     fcstlmfit3 <- forecast(stlmfit2)
-    expect_true(all(round(forecast(stlm(ts(rep(100, 120), f = 12)))$mean, 10) == 100))
-    expect_true(all(round(forecast(stlm(ts(rep(100, 120), f = 12), lambda = 1))$mean, 10) == 100))
+    expect_true(all(round(forecast(stlm(ts(rep(100, 120), frequency = 12)))$mean, 10) == 100))
+    expect_true(all(round(forecast(stlm(ts(rep(100, 120), frequency = 12), lambda = 1))$mean, 10) == 100))
   })
 
   test_that("tests for stlf", {
@@ -64,7 +64,7 @@ if (require(testthat)) {
     fit2 <- stlf(wineind, lambda = .2, biasadj = TRUE)
     expect_false(identical(fit1$mean, fit2$mean))
     # Constant series should not error
-    series <- ts(rep(950, 20), f = 4)
+    series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(stlf(series), NA)
     # Small eps
     expect_true(all(abs(constantForecast$mean - mean(series)) < 10 ^ -8))

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -2,7 +2,7 @@
 if (require(testthat)) {
   context("Tests on input")
 
-  mtsobj <- ts(matrix(rnorm(200), ncol = 2), freq = 4)
+  mtsobj <- ts(matrix(rnorm(200), ncol = 2), frequency = 4)
   test_that("tests specifying correct argument", {
     sub <- subset(wineind, month = "September")
     expect_that(length(sub), equals(tsp(sub)[2] - tsp(sub)[1] + 1))

--- a/tests/testthat/test-thetaf.R
+++ b/tests/testthat/test-thetaf.R
@@ -8,6 +8,6 @@ if (require(testthat)) {
     # Constant series should not error
     series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(thetaf(series), NA)
-    expect_true(is.constant(round(constantForecast$mean,12)))
+    expect_true(is.constant(round(constantForecast$mean, 12)))
   })
 }

--- a/tests/testthat/test-thetaf.R
+++ b/tests/testthat/test-thetaf.R
@@ -6,7 +6,7 @@ if (require(testthat)) {
     expect_error(thetaf(WWWusage, level = -10))
     expect_error(thetaf(WWWusage, level = 110))
     # Constant series should not error
-    series <- ts(rep(950, 20), f = 4)
+    series <- ts(rep(950, 20), frequency = 4)
     constantForecast <- expect_error(thetaf(series), NA)
     expect_true(is.constant(round(constantForecast$mean,12)))
   })


### PR DESCRIPTION
Addresses #841 

There's still partial match warnings that pop up but that's from dependency packages.

I went through the tests to identify partial match issues, so if there's some functions that aren't covered, I most likely missed them.

Also, there's one test case `expect_silent` that I had to remove since `bizdays` gives plenty of partial match warnings. 

Please let me know if you want me to squash commits. 