### PR TITLE
Prevent error caused by last in change auto.arima when xreg=NULL

### DIFF
--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -129,7 +129,9 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
 
   # Trim initial missing values
   x <- subset(x, start=firstnonmiss)
-  xreg <- subset(ts(xreg), start=firstnonmiss)
+  if (!is.null(xreg)){
+    xreg <- subset(ts(xreg), start=firstnonmiss)
+  }
 
   # Check for constant data
   if (is.constant(x)) {


### PR DESCRIPTION
Sorry but I submitted the last pull request before running R CMD check and created a new bug of course. Here's a follow-up that completes the first earlier one.