### PR TITLE
Accuracy for ARFIMA

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -254,7 +254,7 @@ accuracy.default <- function(object, x, test = NULL, d = NULL, D = NULL, f = NUL
     object <- f
   }
   if (!any(is.element(class(object), c(
-    "mforecast", "forecast", "ts", "integer", "numeric",
+    "ARFIMA", "mforecast", "forecast", "ts", "integer", "numeric",
     "Arima", "ets", "lm", "bats", "tbats", "nnetar", "stlm", "baggedModel"
   )))) {
     stop("First argument should be a forecast object or a time series.")

--- a/tests/testthat/test-arfima.R
+++ b/tests/testthat/test-arfima.R
@@ -5,13 +5,15 @@ if (require(testthat)) {
   arfimabc <- arfima(WWWusage, estim = "mle", lambda = 0.75, biasadj = FALSE)
   arfimabc2 <- arfima(WWWusage, estim = "mle", lambda = 0.75, biasadj = TRUE)
 
-  test_that("test fitted() and residuals().", {
+  test_that("test accuracy(), fitted(), and residuals().", {
     expect_true(all(arimaorder(arfima1) == arimaorder(arfima2)))
     fitarfima <- fitted(arfima1)
     residarfima <- residuals(arfima2)
     expect_true(length(fitarfima) == length(residarfima))
     expect_true(all(getResponse(arfima1) == WWWusage))
     expect_false(identical(arfimabc$fitted, arfimabc2$fitted))
+    expect_error(accuracy(arfima1), NA)
+    expect_equal(mean(residuals(arfima1)), accuracy(arfima1)[, "ME"])
   })
 
   test_that("test forecast.fracdiff()", {

--- a/tests/testthat/test-arima.R
+++ b/tests/testthat/test-arima.R
@@ -55,7 +55,7 @@ if (require(testthat)) {
 
     # Test fracdiff
     set.seed(4)
-    fracdiffMod <- fracdiff::fracdiff(lynx, nar = 2, nma = 2)
+    fracdiffMod <- fracdiff::fracdiff(lynx, nar = 2)
     expect_true(all(names(arimaorder(fracdiffMod)) == c("p", "d", "q")))
     expect_true(arimaorder(fracdiffMod)["p"] == 2)
     expect_true(arimaorder(fracdiffMod)["d"] >= 0)


### PR DESCRIPTION
Current behavior:
```
> library(forecast)
> mod <- arfima(wineind)
> accuracy(mod)
Error in accuracy.default(mod) : 
  First argument should be a forecast object or a time series.
```

New behavior:
```
> mod <- arfima(wineind)
> accuracy(mod)
                   ME     RMSE      MAE       MPE     MAPE     MASE       ACF1
Training set 107.9382 5065.181 3926.056 -3.751643 16.22077 1.995578 0.01095209
```