### PR TITLE
Parallel computing when using `auto.arima()`

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -65,8 +65,9 @@ search.arima <- function(x, d=NA, D=NA, max.p=5, max.q=5,
       num.cores <- detectCores()
     }
     cl <- makeCluster(num.cores)
-    #exporting the max.order object in the cluster
-    #clusterExport(cl,c("max.order"))
+    #exporting the objects needed in all nodes of the cluster
+    clusterExport(cl,c("max.p", "max.q", "max.P", "max.Q", "max.order"))
+    
     all.models <- parLapply(cl = cl, X = to.check, fun = par.all.arima)
     stopCluster(cl = cl)
 

--- a/R/arima.R
+++ b/R/arima.R
@@ -66,7 +66,7 @@ search.arima <- function(x, d=NA, D=NA, max.p=5, max.q=5,
     }
     cl <- makeCluster(num.cores)
     #exporting the objects needed in all nodes of the cluster
-    clusterExport(cl, c("max.p", "max.q", "max.P", "max.Q", "max.order"), envir=environment())
+    clusterExport(cl, c("max.order"), envir=environment())
 
     all.models <- parLapply(cl = cl, X = to.check, fun = par.all.arima)
     stopCluster(cl = cl)

--- a/R/arima.R
+++ b/R/arima.R
@@ -66,8 +66,8 @@ search.arima <- function(x, d=NA, D=NA, max.p=5, max.q=5,
     }
     cl <- makeCluster(num.cores)
     #exporting the objects needed in all nodes of the cluster
-    clusterExport(cl,c("max.p", "max.q", "max.P", "max.Q", "max.order"))
-    
+    clusterExport(cl, c("max.p", "max.q", "max.P", "max.Q", "max.order"), envir=environment())
+
     all.models <- parLapply(cl = cl, X = to.check, fun = par.all.arima)
     stopCluster(cl = cl)
 


### PR DESCRIPTION
fixes issue #855 and fixes pull request #830


The cluster of nodes is created in the non-exported function `search.arima()`. The nodes are unable to access the variables that are passed to this function because the cluster is defined/created _inside_ the `search.arima()` function. 

The nodes cannot access the variables because the variables that are able to be accessed come from the default for the function `clusterExport()` which is `clusterExport(cl = NULL, varlist, envir = .GlobalEnv)`. The variables passed into `search.arima()` do not exists at the `.GlobalEnv` level, they exist within the local function. Thus, we set `envir=environment()` to capture this  function's variables which allows `par.all.arima()` to access them when on other nodes:  `all.models <- parLapply(cl = cl, X = to.check, fun = par.all.arima)`.

Note: only the `max.order` variable was exported - however more can be added simply by adding them to the `c("max.order")` array in 
``` R
#exporting the objects needed in all nodes of the cluster
clusterExport(cl, c("max.order"), envir=environment())
```
