### PR TITLE
Make use of the "labels" parameter in ggsubseriesplot

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -1241,7 +1241,14 @@ ggsubseriesplot <- function(x, labels = NULL, times = time(x), phase = cycle(x),
 
     # Create x-axis labels
     xfreq <- frequency(x)
-    if (xfreq == 4) {
+    if (!is.null(labels)) {
+      if (xfreq != length(labels)) {
+        stop("The number of labels supplied is not the same as the number of seasons.")
+      } else {
+        xbreaks <- labels
+      }
+    }
+    else if (xfreq == 4) {
       xbreaks <- c("Q1", "Q2", "Q3", "Q4")
       xlab <- "Quarter"
     }


### PR DESCRIPTION
"labels" was left unused in ggsubseriesplot().
This commit makes the function check if labels is supplied and give priority to the user-supplied labels.