### PR TITLE
Print right ARIMA model when trace=TRUE

### DIFF
--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -784,11 +784,13 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
     if (minroot < 1 + 1e-2 | checkarima(fit)) {
       fit$ic <- Inf
     }
+    
+    fit$xreg <- xreg
+    
     if (trace) {
       cat("\n", arima.string(fit, padding = TRUE), ":", fit$ic)
     }
-    fit$xreg <- xreg
-
+    
     return(structure(fit, class = c("forecast_ARIMA", "ARIMA", "Arima")))
   }
   else {


### PR DESCRIPTION
I noticed that `auto.arima` does not print the complete model information when `xreg` and `trace=TRUE` are used. I think it should print `Regression with {arima model} errors` at each step.

<img width="585" alt="image" src="https://user-images.githubusercontent.com/10517170/155811429-b89416af-138d-4204-a286-7d9f8f6d4f56.png">

The problem arises due to the following lines,
https://github.com/robjhyndman/forecast/blob/e9c4d22f57835748c53453edbca564ca5d15089a/R/newarima2.R#L786-L790

Since `xreg` is added to `fit` after `cat`, `arima.string` ignores it, according to the following lines,

https://github.com/robjhyndman/forecast/blob/e9c4d22f57835748c53453edbca564ca5d15089a/R/newarima2.R#L849-L855

This PR solves the problem.