### PR TITLE
Update package docs to avoid conflict with generics::forecast reexport

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,4 @@ License: GPL-3
 URL: https://pkg.robjhyndman.com/forecast/, https://github.com/robjhyndman/forecast
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/forecast-package.R
+++ b/R/forecast-package.R
@@ -1,4 +1,5 @@
 #' @keywords package
+#' @aliases forecast-package
 "_PACKAGE"
 
 #' @import parallel

--- a/man/forecast-package.Rd
+++ b/man/forecast-package.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/forecast-package.R
 \docType{package}
 \name{forecast-package}
-\alias{forecast}
 \alias{forecast-package}
+\alias{_PACKAGE}
 \title{forecast: Forecasting Functions for Time Series and Linear Models}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}


### PR DESCRIPTION
Fix `"_PACKAGE"` documentation alias conflict check errors.

https://roxygen2.r-lib.org/articles/rd.html#packages
> By default, aliases will be added so that both `?pkgname` and `package?pkgname` will find the package help. If there’s an existing function called pkgname, use `@aliases {pkgname}-package` to override the default.