### PR TITLE
update bizdays tests for timeDate (>= 4021.105)

### DIFF
--- a/tests/testthat/test-calendar.R
+++ b/tests/testthat/test-calendar.R
@@ -6,12 +6,16 @@ if (require(testthat)) {
     b1 <- bizdays(woolyrnq, FinCenter = "New York")
     b2 <- bizdays(woolyrnq, FinCenter = "London")
     b3 <- bizdays(woolyrnq, FinCenter = "Zurich")
-    expect_equal(sum(abs(b1 - b2)), 109L)
-    expect_equal(sum(abs(b1 - b3)), 144L)
+    if(packageVersion("timeDate") >= '4021.105') {
+        expect_equal(sum(abs(b1 - b2)), 145L)
+        expect_equal(sum(abs(b1 - b3)), 176L)
+    }
     expect_equal(sum(abs(b2 - b3)), 117L)
-    #b1 <- bizdays(gas, FinCenter = "NERC")
-    #b2 <- bizdays(gas, FinCenter = "Tokyo")
-    #expect_equal(sum(abs(b1 - b2)), 244L)
+    b1 <- bizdays(gas, FinCenter = "NERC")
+    b2 <- bizdays(gas, FinCenter = "Toronto")
+    if(packageVersion("timeDate") >= '4021.105') {
+        expect_equal(sum(abs(b1 - b2)), 211L)
+    }
   })
 
   test_that("Tests for easter()", {


### PR DESCRIPTION
This updates the `bizdays()` tests to work with the updated information in 'timeDate'. I have made them conditional on 
'timeDate (>= 4021.105)', since the values returned by older versions were incorrect in some cases.
I would appreciate if you could update 'forecast' on CRAN since I need to submit a revision to deal with a new error in timeDate due to a recent change  in R-devel of as.character() for `POSIX*t` objects.

Long story: 
I have completed the update for the New York stock exchange's non-business days. I used information from NSE itself, so they should be complete. Further changes to historical holidays will be needed only if there are bugs. Similarly for Toronto, but not so exhaustively. Also, although the holiday functions in 'timeDate' technically may be correct to return only official holidays (and not off-days due to hurricanes or snow, for example) users actually expect that all non-business days are returned. I have now amended the holiday function for the NSE to do exactly that. So, now the complement of its result (+ weekends) should really give the non-business days for NSE. 