### PR TITLE
Allow nnetar models with only seasonal lags

### DIFF
--- a/tests/testthat/test-nnetar.R
+++ b/tests/testthat/test-nnetar.R
@@ -32,6 +32,27 @@ if (require(testthat)) {
       fixed = TRUE
     )
     expect_true(uscnnet$size == 3)
+    # Test default size for models with only seasonal lags, with and without xreg
+    seasonal_only_lags_nnet <- nnetar(woolyrnq,p = 0,P = 3)
+    expect_output(
+      print(seasonal_only_lags_nnet),regexp = "NNAR(0,3,2)",
+      fixed = TRUE
+    )
+    expect_output(
+      print(seasonal_only_lags_nnet),regexp = "3-2-1 network",
+      fixed = TRUE
+    )
+
+    seasonal_only_lags_xreg_nnet <- nnetar(woolyrnq,p = 0,P = 3,xreg = cbind(1:119,119:1))
+    expect_output(
+      print(seasonal_only_lags_xreg_nnet),regexp = "NNAR(0,3,3)",
+      fixed = TRUE
+    )
+    expect_output(
+      print(seasonal_only_lags_xreg_nnet),regexp = "5-3-1 network",
+      fixed = TRUE
+    )
+
     # Test P=0 when m>1
     uscnnet <- nnetar(woolyrnq, p = 4, P = 0)
     expect_true(uscnnet$size == 2)
@@ -46,6 +67,10 @@ if (require(testthat)) {
     expect_output(
       print(uscnnet), regexp = "5-3-1 network",
       fixed = TRUE
+    )
+    # Test that p = 0 & P = 0 is not permitted
+    expect_error(
+      nnetar(woolyrnq,p = 0,P = 0)
     )
     # Test with multiple-column xreg
     creditnnet <- nnetar(


### PR DESCRIPTION
Closes issue [#935](https://github.com/robjhyndman/forecast/issues/935).  

- Changes the creation of the vector `lags` in the case when `p = 0` and `P > 0` to the correct collection of lags by checking for that combination of inputs and using `seq_len()` rather than `1:p` for safety.
- Adds a check in `nnetar()` that will `stop()` with an error if both `p = 0` and `P = 0`, so at least one type of lag must be requested.
- In the case of non-seasonal data (`m = 1`) if the user sets `p = 0`, it will fall back to the default calculation for `p` with a warning.
- Modifies description of the argument `p` to document what happens if `p = 0`
- Added tests for the seasonal only lag case mimicking the existing tests for default size
- Added test for stopping in the case that the user sets both `p = 0` and `P = 0`