### PR TITLE
refactor: use more `inherits()` for error checking

### DIFF
--- a/R/arfima.R
+++ b/R/arfima.R
@@ -163,10 +163,10 @@ arfima <- function(y, drange = c(0, 0.5), estim = c("mle", "ls"), model = NULL, 
       p <- length(fit$ar)
       q <- length(fit$ma)
       fit2 <- try(Arima(y, order = c(p, 0, q), include.mean = FALSE))
-      if (is.element("try-error", class(fit2))) {
+      if (inherits(fit2, "try-error")) {
         fit2 <- try(Arima(y, order = c(p, 0, q), include.mean = FALSE, method = "ML"))
       }
-      if (!is.element("try-error", class(fit2))) {
+      if (!inherits(fit2, "try-error")) {
         if (p > 0) {
           fit$ar <- fit2$coef[1:p]
         }

--- a/R/checkresiduals.R
+++ b/R/checkresiduals.R
@@ -44,7 +44,7 @@ checkresiduals <- function(object, lag, test, plot = TRUE, ...) {
   }
 
   # Extract residuals
-  if (is.element("ts", class(object)) || is.element("numeric", class(object))) {
+  if (is.ts(object) || is.numeric(object)) {
     residuals <- object
     object <- list(method = "Missing")
   } else {

--- a/R/ets.R
+++ b/R/ets.R
@@ -422,7 +422,7 @@ ets <- function(y, model="ZZZ", damped=NULL,
             y, errortype[i], trendtype[j], seasontype[k], damped[l], alpha, beta, gamma, phi,
             lower = lower, upper = upper, opt.crit = opt.crit, nmse = nmse, bounds = bounds, ...
           ), silent=TRUE)
-          if(is.element("try-error", class(fit)))
+          if(inherits(fit, "try-error"))
             fit.ic <- Inf
           else
             fit.ic <- switch(ic, aic = fit$aic, bic = fit$bic, aicc = fit$aicc)

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -312,7 +312,7 @@ plot.forecast <- function(x, include, PI=TRUE, showgap = TRUE, shaded=TRUE, shad
     x$lower <- as.matrix(x$lower)
   }
 
-  if (is.element("lm", class(x$model)) && !is.element("ts", class(x$mean))) # Non time series linear model
+  if (inherits(x$model, "lm") && !is.ts(x$mean)) # Non time series linear model
   {
     plotlmforecast(
       x, PI = PI, shaded = shaded, shadecols = shadecols, col = col, fcol = fcol, pi.col = pi.col, pi.lty = pi.lty,
@@ -499,7 +499,7 @@ hfitted.default <- function(object, h=1, FUN=NULL, ...) {
       }
     }
     fcarg$object <- try(suppressWarnings(do.call(FUN, refitarg)), silent = TRUE)
-    if (!is.element("try-error", class(fcarg$object))) {
+    if (!inherits(fcarg$object, "try-error")) {
       # Keep original variance estimate (for consistent bias adjustment)
       if(!is.null(object$sigma2))
         fcarg$object$sigma2 <- object$sigma2

--- a/R/getResponse.R
+++ b/R/getResponse.R
@@ -55,10 +55,10 @@ getResponse.Arima <- function(object, ...) {
       return(NULL)
     } else {
       x <- try(eval.parent(parse(text = series.name)), silent = TRUE)
-      if (is.element("try-error", class(x))) { # Try one level further up the chain
+      if (inherits(x, "try-error")) { # Try one level further up the chain
         x <- try(eval.parent(parse(text = series.name), 2), silent = TRUE)
       }
-      if (is.element("try-error", class(x))) { # Give up
+      if (inherits(x, "try-error")) { # Give up
         return(NULL)
       }
     }
@@ -77,10 +77,10 @@ getResponse.fracdiff <- function(object, ...) {
       stop("missing original time series")
     } else {
       x <- try(eval.parent(parse(text = series.name)), silent = TRUE)
-      if (is.element("try-error", class(x))) { # Try one level further up the chain
+      if (inherits(x, "try-error")) { # Try one level further up the chain
         x <- try(eval.parent(parse(text = series.name), 2), silent = TRUE)
       }
-      if (is.element("try-error", class(x))) { # Give up
+      if (inherits(x, "try-error")) { # Give up
         return(NULL)
       }
     }

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -648,7 +648,7 @@ autoplot.forecast <- function(object, include, PI=TRUE, shadecols=c("#596DD5", "
     p <- ggplot2::ggplot()
 
     # Cross sectional forecasts
-    if (!is.element("ts", class(object$mean))) {
+    if (!is.ts(object$mean)) {
       if (length(xvar) > 1) {
         stop("Forecast plot for regression models only available for a single predictor")
       }
@@ -1936,7 +1936,7 @@ fortify.ts <- function(model, data, ...) {
 
 forecast2plotdf <- function(model, data=as.data.frame(model), PI=TRUE, showgap=TRUE, ...) {
   # Time series forecasts
-  if (is.element("ts", class(model$mean))) {
+  if (is.ts(model$mean)) {
     xVals <- as.numeric(time(model$mean)) # x axis is time
   }
   # Cross-sectional forecasts

--- a/R/lm.R
+++ b/R/lm.R
@@ -39,7 +39,7 @@ tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
   }
   if (missing(data)) {
     mt <- try(terms(formula))
-    if (is.element("try-error", class(mt))) {
+    if (inherits(mt, "try-error")) {
       stop("Cannot extract terms from formula, please provide data argument.")
     }
   }
@@ -262,7 +262,7 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
   }
   else if (!is.null(object$call$data)) {
     origdata <- try(object$data <- eval(object$call$data), silent = TRUE)
-    if (is.element("try-error", class(origdata))) {
+    if (inherits(origdata, "try-error")) {
       stop("Could not find data. Try training your model using tslm() or attach data directly to the object via object$data<-modeldata for some object<-lm(formula,modeldata).")
     }
   }
@@ -277,15 +277,15 @@ forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambd
   }
 
   # Check if the forecasts will be time series
-  if (ts && is.element("ts", class(origdata))) {
+  if (ts && is.ts(origdata)) {
     tspx <- tsp(origdata)
     timesx <- time(origdata)
   }
-  else if (ts && is.element("ts", class(origdata[, 1]))) {
+  else if (ts && is.ts(origdata[, 1])) {
     tspx <- tsp(origdata[, 1])
     timesx <- time(origdata[, 1])
   }
-  else if (ts && is.element("ts", class(fitted(object)))) {
+  else if (ts && is.ts(fitted(object))) {
     tspx <- tsp(fitted(object))
     timesx <- time(fitted(object))
   }

--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -344,7 +344,7 @@ auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,
         xreg = xreg, ...
       ), silent = TRUE)
     }
-    if (!is.element("try-error", class(fit))) {
+    if (!inherits(fit, "try-error")) {
       offset <- -2 * fit$loglik - serieslength * log(fit$sigma2)
     } else # Not sure this should ever happen
     {
@@ -720,7 +720,7 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
   } else {
     nxreg <- ncol(as.matrix(xreg))
   }
-  if (!is.element("try-error", class(fit))) {
+  if (!inherits(fit, "try-error")) {
     nstar <- n - order[2] - seasonal[2] * m
     if (diffs == 1 && constant) {
       # fitnames <- names(fit$coef)
@@ -756,7 +756,7 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
       if (last.nonzero > 0) {
         testvec <- testvec[1:last.nonzero]
         proots <- try(polyroot(c(1,-testvec)))
-        if (!is.element("try-error", class(proots))) {
+        if (!inherits(proots, "try-error")) {
           minroot <- min(minroot, abs(proots))
         }
         else fit$ic <- Inf
@@ -773,7 +773,7 @@ myarima <- function(x, order = c(0, 0, 0), seasonal = c(0, 0, 0), constant=TRUE,
       if (last.nonzero > 0) {
         testvec <- testvec[1:last.nonzero]
         proots <- try(polyroot(c(1,testvec)))
-        if (!is.element("try-error", class(proots))) {
+        if (!inherits(proots, "try-error")) {
           minroot <- min(minroot, abs(proots))
         }
         else fit$ic <- Inf

--- a/R/tbats.R
+++ b/R/tbats.R
@@ -195,7 +195,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
     k.vector = k.vector, init.box.cox = init.box.cox,
     bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj
   ), silent = TRUE)
-  if (is.element("try-error", class(best.model))) {
+  if (inherits(best.model, "try-error")) {
     best.model <- list(AIC = Inf)
   }
 
@@ -240,7 +240,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
           ),
           silent = TRUE
         )
-        if (is.element("try-error", class(new.model))) {
+        if (inherits(new.model, "try-error")) {
           new.model <- list(AIC = Inf)
         }
 
@@ -288,7 +288,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
           ),
           silent = TRUE
         )
-        if (is.element("try-error", class(up.model))) {
+        if (inherits(up.model, "try-error")) {
           up.model <- list(AIC = Inf)
         }
         level.model <- try(
@@ -299,7 +299,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
           ),
           silent = TRUE
         )
-        if (is.element("try-error", class(level.model))) {
+        if (inherits(level.model, "try-error")) {
           level.model <- list(AIC = Inf)
         }
         down.model <- try(
@@ -310,7 +310,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
           ),
           silent = TRUE
         )
-        if (is.element("try-error", class(down.model))) {
+        if (inherits(down.model, "try-error")) {
           down.model <- list(AIC = Inf)
         }
       }
@@ -330,7 +330,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
             ),
             silent = TRUE
           )
-          if (is.element("try-error", class(down.model))) {
+          if (inherits(down.model, "try-error")) {
             down.model <- list(AIC = Inf)
           }
           if (down.model$AIC > best.model$AIC) {
@@ -358,7 +358,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
             fitSpecificTBATS(y, model.params[1], model.params[2], model.params[3], seasonal.periods, k.vector, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj),
             silent = TRUE
           )
-          if (is.element("try-error", class(up.model))) {
+          if (inherits(up.model, "try-error")) {
             up.model <- list(AIC = Inf)
           }
           if (up.model$AIC > best.model$AIC) {
@@ -460,13 +460,13 @@ parFilterTBATSSpecifics <- function(control.number, y, control.array, model.para
     first.model <- aux.model
   }
 
-  if (is.element("try-error", class(first.model))) {
+  if (inherits(first.model, "try-error")) {
     first.model <- list(AIC = Inf)
   }
 
   if (use.arma.errors) {
     suppressWarnings(arma <- try(auto.arima(as.numeric(first.model$errors), d = 0, ...), silent = TRUE))
-    if (!is.element("try-error", class(arma))) {
+    if (!inherits(arma, "try-error")) {
       p <- arma$arma[1]
       q <- arma$arma[2]
       if ((p != 0) || (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
@@ -486,7 +486,7 @@ parFilterTBATSSpecifics <- function(control.number, y, control.array, model.para
           fitSpecificTBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = seasonal.periods, k.vector = k.vector, ar.coefs = ar.coefs, ma.coefs = ma.coefs, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj),
           silent = TRUE
         )
-        if (is.element("try-error", class(second.model))) {
+        if (inherits(second.model, "try-error")) {
           second.model <- list(AIC = Inf)
         }
         if (second.model$AIC < first.model$AIC) {
@@ -513,7 +513,7 @@ parFitSpecificTBATS <- function(control.number, y, box.cox, trend, damping, seas
     fitSpecificTBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = seasonal.periods, k.vector = k.vector, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj),
     silent = TRUE
   )
-  if (is.element("try-error", class(model))) {
+  if (inherits(model, "try-error")) {
     model <- list(AIC = Inf)
   }
   return(model)
@@ -528,13 +528,13 @@ filterTBATSSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, k
   } else {
     first.model <- aux.model
   }
-  if (is.element("try-error", class(first.model))) {
+  if (inherits(first.model, "try-error")) {
     first.model <- list(AIC = Inf)
   }
 
   if (use.arma.errors) {
     suppressWarnings(arma <- try(auto.arima(as.numeric(first.model$errors), d = 0, ...), silent = TRUE))
-    if (!is.element("try-error", class(arma))) {
+    if (!inherits(arma, "try-error")) {
       p <- arma$arma[1]
       q <- arma$arma[2]
       if ((p != 0) || (q != 0)) { # Did auto.arima() find any AR() or MA() coefficients?
@@ -554,7 +554,7 @@ filterTBATSSpecifics <- function(y, box.cox, trend, damping, seasonal.periods, k
           fitSpecificTBATS(y, use.box.cox = box.cox, use.beta = trend, use.damping = damping, seasonal.periods = seasonal.periods, k.vector = k.vector, ar.coefs = ar.coefs, ma.coefs = ma.coefs, init.box.cox = init.box.cox, bc.lower = bc.lower, bc.upper = bc.upper, biasadj = biasadj),
           silent = TRUE
         )
-        if (is.element("try-error", class(second.model))) {
+        if (inherits(second.model, "try-error")) {
           second.model <- list(AIC = Inf)
         }
 

--- a/R/tscv.R
+++ b/R/tscv.R
@@ -103,7 +103,7 @@ tsCV <- function(y, forecastfunction, h=1, window=NULL, xreg=NULL, initial=0, ..
         forecastfunction(y_subset, h = h, xreg = xreg_subset, newxreg=xreg_future, ...)
         ), silent = TRUE)
     }
-    if (!is.element("try-error", class(fc))) {
+    if (!inherits(fc, "try-error")) {
       e[i, ] <- y[i + seq(h)] - fc$mean[seq(h)]
     }
   }


### PR DESCRIPTION
- replace `is.element("try-error", class(x))` with `inherits(x, "try-error")`
- replace `is.element("ts", class(x))` with `is.ts(x)`
- replace `is.element("numeric", class(x))` with `is.numeric(x)`
