### PR TITLE
refactor: remove redundant equals test in logical expressions

### DIFF
--- a/R/HoltWintersNew.R
+++ b/R/HoltWintersNew.R
@@ -264,7 +264,7 @@ HoltWintersZZ <- function(x,
 zzhw <- function(x, lenx, alpha=NULL, beta=NULL, gamma=NULL, seasonal="additive", m,
                  dotrend=FALSE, doseasonal=FALSE, l.start=NULL, exponential = NULL, phi=NULL,
                  b.start=NULL, s.start=NULL) {
-  if (exponential != TRUE || is.null(exponential)) {
+  if (!exponential || is.null(exponential)) {
     exponential <- FALSE
   }
 

--- a/R/arima.R
+++ b/R/arima.R
@@ -13,7 +13,7 @@ search.arima <- function(x, d=NA, D=NA, max.p=5, max.q=5,
 
   # Choose model orders
   # Serial - technically could be combined with the code below
-  if (parallel == FALSE) {
+  if (!parallel) {
     best.ic <- Inf
     for (i in 0:max.p) {
       for (j in 0:max.q) {
@@ -37,7 +37,7 @@ search.arima <- function(x, d=NA, D=NA, max.p=5, max.q=5,
         }
       }
     }
-  } else if (parallel == TRUE) {
+  } else if (parallel) {
     to.check <- WhichModels(max.p, max.q, max.P, max.Q, maxK)
 
     par.all.arima <- function(l, max.order) {

--- a/R/bats.R
+++ b/R/bats.R
@@ -137,7 +137,7 @@ bats <- function(y, use.box.cox = NULL, use.trend = NULL, use.damped.trend = NUL
       # In the this case, there is only one alternative.
       use.parallel <- FALSE
     }
-    else if (use.trend == FALSE) {
+    else if (!use.trend) {
       # As above, in the this case, there is only one alternative.
       use.parallel <- FALSE
     }
@@ -164,7 +164,7 @@ bats <- function(y, use.box.cox = NULL, use.trend = NULL, use.damped.trend = NUL
   if (is.null(use.trend)) {
     use.trend <- c(FALSE, TRUE)
   }
-  else if (use.trend == FALSE) {
+  else if (!use.trend) {
     use.damped.trend <- FALSE
   }
   if (is.null(use.damped.trend)) {

--- a/R/checkresiduals.R
+++ b/R/checkresiduals.R
@@ -36,7 +36,7 @@ checkresiduals <- function(object, lag, test, plot = TRUE, ...) {
       test <- "LB"
     }
     showtest <- TRUE
-  } else if (test != FALSE) {
+  } else if (test) {
     test <- match.arg(test, c("LB", "BG"))
     showtest <- TRUE
   } else {

--- a/R/fitBATS.R
+++ b/R/fitBATS.R
@@ -5,7 +5,7 @@
 
 fitPreviousBATSModel <- function(y, model, biasadj=FALSE) {
   seasonal.periods <- model$seasonal.periods
-  if (is.null(seasonal.periods) == FALSE) {
+  if (!is.null(seasonal.periods)) {
     seasonal.periods <- as.integer(sort(seasonal.periods))
   }
   paramz <- unParameterise(model$parameters$vect, model$parameters$control)

--- a/R/fitTBATS.R
+++ b/R/fitTBATS.R
@@ -1,6 +1,6 @@
 fitPreviousTBATSModel <- function(y, model, biasadj=FALSE) {
   seasonal.periods <- model$seasonal.periods
-  if (is.null(seasonal.periods) == FALSE) {
+  if (!is.null(seasonal.periods)) {
     seasonal.periods <- sort(seasonal.periods)
   }
   # Get the parameters out of the param.vector
@@ -48,7 +48,7 @@ fitPreviousTBATSModel <- function(y, model, biasadj=FALSE) {
   }
 
   y.touse <- y
-  if (is.null(lambda) == FALSE) {
+  if (!is.null(lambda)) {
     y.touse <- BoxCox(y, lambda = lambda)
     lambda <- attr(y.touse, "lambda")
   }

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -224,7 +224,7 @@ myarima.sim <- function(model, n, x, e, ...) {
       # AR filtering for all other cases where AR is used.
       x <- stats::filter(x, model$ar, method = "recursive")
     }
-  if ((d == 0) && (D == 0) && (flag.noadjust == FALSE)) # Adjust to ensure end matches approximately
+  if ((d == 0) && (D == 0) && !flag.noadjust) # Adjust to ensure end matches approximately
     {
       # Last 20 diffs
       if (n.start >= 20) {
@@ -240,7 +240,7 @@ myarima.sim <- function(model, n, x, e, ...) {
       }
       x <- x + xdiff
     }
-  if ((n.start > 0) && (flag.noadjust == FALSE)) {
+  if ((n.start > 0) && !flag.noadjust) {
     x <- x[-(1:n.start)]
   }
 

--- a/R/tbats.R
+++ b/R/tbats.R
@@ -166,7 +166,7 @@ tbats <- function(y, use.box.cox=NULL, use.trend=NULL, use.damped.trend=NULL,
   }
   if (is.null(use.trend)) {
     use.trend <- c(FALSE, TRUE)
-  } else if (use.trend == FALSE) {
+  } else if (!use.trend) {
     use.damped.trend <- FALSE
   }
   if (is.null(use.damped.trend)) {


### PR DESCRIPTION
Some of the exported functions with boolean args, might also benefit from the `isTRUE(x)`/`isFALSE(x)` pattern to make them more robust.