### PR TITLE
docs: add sentence about parallel for window usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,5 +66,5 @@ License: GPL-3
 URL: https://pkg.robjhyndman.com/forecast/, https://github.com/robjhyndman/forecast
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3

--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -66,8 +66,9 @@
 #' @param allowdrift If \code{TRUE}, models with drift terms are considered.
 #' @param allowmean If \code{TRUE}, models with a non-zero mean are considered.
 #' @param parallel If \code{TRUE} and \code{stepwise = FALSE}, then the
-#' specification search is done in parallel. This can give a significant
-#' speedup on multicore machines.
+#' specification search is done in parallel via \code{parallel::mclapply}. This
+#' can give a significant speedup on multicore machines. On Windows, this
+#' option always fails because forking is not supported.
 #' @param num.cores Allows the user to specify the amount of parallel processes
 #' to be used if \code{parallel = TRUE} and \code{stepwise = FALSE}. If
 #' \code{NULL}, then the number of logical cores is automatically detected and

--- a/man/auto.arima.Rd
+++ b/man/auto.arima.Rd
@@ -139,8 +139,9 @@ biasadj is \code{TRUE}, an adjustment will be made to produce mean forecasts
 and fitted values.}
 
 \item{parallel}{If \code{TRUE} and \code{stepwise = FALSE}, then the
-specification search is done in parallel. This can give a significant
-speedup on multicore machines.}
+specification search is done in parallel via \code{parallel::mclapply}. This
+can give a significant speedup on multicore machines. On Windows, this
+option always fails because forking is not supported.}
 
 \item{num.cores}{Allows the user to specify the amount of parallel processes
 to be used if \code{parallel = TRUE} and \code{stepwise = FALSE}. If


### PR DESCRIPTION
Might also make sense to either fail early under Windows or set the number of cores to one with a warning/message.