### PR TITLE
feat(Arima): set include.constant to default NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,5 +66,5 @@ License: GPL-3
 URL: https://pkg.robjhyndman.com/forecast/, https://github.com/robjhyndman/forecast
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3

--- a/R/arima.R
+++ b/R/arima.R
@@ -690,7 +690,7 @@ fitted.forecast_ARIMA <- fitted.Arima
 #'          log(window(AirPassengers,start=1957)))
 #'
 Arima <- function(y, order=c(0, 0, 0), seasonal=c(0, 0, 0), xreg=NULL, include.mean=TRUE,
-                  include.drift=FALSE, include.constant, lambda=model$lambda, biasadj=FALSE,
+                  include.drift=FALSE, include.constant=NULL, lambda=model$lambda, biasadj=FALSE,
                   method=c("CSS-ML", "ML", "CSS"), model=NULL, x=y, ...) {
   # Remove outliers near ends
   # j <- time(x)
@@ -731,8 +731,8 @@ Arima <- function(y, order=c(0, 0, 0), seasonal=c(0, 0, 0), xreg=NULL, include.m
     }
   }
 
-  if (!missing(include.constant)) {
-    if (include.constant) {
+  if (!is.null(include.constant)) {
+    if (isTRUE(include.constant)) {
       include.mean <- TRUE
       if ((order[2] + seasonal$order[2]) == 1) {
         include.drift <- TRUE

--- a/man/Arima.Rd
+++ b/man/Arima.Rd
@@ -14,7 +14,7 @@ Arima(
   xreg = NULL,
   include.mean = TRUE,
   include.drift = FALSE,
-  include.constant,
+  include.constant = NULL,
   lambda = model$lambda,
   biasadj = FALSE,
   method = c("CSS-ML", "ML", "CSS"),


### PR DESCRIPTION
include.constant is one of the last places that use missing for the default value instead of NULL and would match more of the rest of the args.