### PR TITLE
docs: remove package alias and move to internal keyword

### DIFF
--- a/R/forecast-package.R
+++ b/R/forecast-package.R
@@ -1,5 +1,4 @@
-#' @keywords package
-#' @aliases forecast-package
+#' @keywords internal
 "_PACKAGE"
 
 #' @import parallel

--- a/man/forecast-package.Rd
+++ b/man/forecast-package.Rd
@@ -50,4 +50,4 @@ Other contributors:
 }
 
 }
-\keyword{package}
+\keyword{internal}


### PR DESCRIPTION
Same style as in tidyverts and tidyverse packages.