### PR TITLE
docs: add whitespace around infix operators in examples

### DIFF
--- a/R/HoltWintersNew.R
+++ b/R/HoltWintersNew.R
@@ -456,7 +456,7 @@ zzhw <- function(x, lenx, alpha=NULL, beta=NULL, gamma=NULL, seasonal="additive"
 #'
 #' fcast <- holt(airmiles)
 #' plot(fcast)
-#' deaths.fcast <- hw(USAccDeaths, h=48)
+#' deaths.fcast <- hw(USAccDeaths, h = 48)
 #' plot(deaths.fcast)
 #'
 #' @export

--- a/R/acf.R
+++ b/R/acf.R
@@ -61,8 +61,8 @@
 #' Acf(wineind)
 #' Pacf(wineind)
 #' \dontrun{
-#' taperedacf(wineind, nsim=50)
-#' taperedpacf(wineind, nsim=50)
+#' taperedacf(wineind, nsim = 50)
+#' taperedpacf(wineind, nsim = 50)
 #' }
 #'
 #' @export

--- a/R/arfima.R
+++ b/R/arfima.R
@@ -115,7 +115,7 @@ unfracdiff <- function(x, y, n, h, d) {
 #' @examples
 #'
 #' library(fracdiff)
-#' x <- fracdiff.sim(100, ma=-.4, d=.3)$series
+#' x <- fracdiff.sim(100, ma = -0.4, d = 0.3)$series
 #' fit <- arfima(x)
 #' tsdisplay(residuals(fit))
 #'

--- a/R/arima.R
+++ b/R/arima.R
@@ -667,18 +667,20 @@ fitted.forecast_ARIMA <- fitted.Arima
 #' @examples
 #' library(ggplot2)
 #' WWWusage %>%
-#'   Arima(order=c(3, 1, 0)) %>%
-#'   forecast(h=20) %>%
+#'   Arima(order = c(3, 1, 0)) %>%
+#'   forecast(h = 20) %>%
 #'   autoplot
 #'
 #' # Fit model to first few years of AirPassengers data
-#' air.model <- Arima(window(AirPassengers, end=1956+11/12), order=c(0, 1, 1),
-#'                    seasonal=list(order=c(0, 1, 1),period=12), lambda=0)
-#' plot(forecast(air.model, h=48))
+#' air.model <- Arima(window(AirPassengers, end = 1956 + 11 / 12),
+#'                    order = c(0, 1, 1),
+#'                    seasonal = list(order = c(0, 1, 1), period = 12),
+#'                    lambda = 0)
+#' plot(forecast(air.model, h = 48))
 #' lines(AirPassengers)
 #'
 #' # Apply fitted model to later data
-#' air.model2 <- Arima(window(AirPassengers, start=1957), model=air.model)
+#' air.model2 <- Arima(window(AirPassengers, start = 1957), model = air.model)
 #'
 #' # Forecast accuracy measures on the log scale.
 #' # in-sample one-step forecasts.
@@ -686,8 +688,8 @@ fitted.forecast_ARIMA <- fitted.Arima
 #' # out-of-sample one-step forecasts.
 #' accuracy(air.model2)
 #' # out-of-sample multi-step forecasts
-#' accuracy(forecast(air.model, h=48, lambda=NULL),
-#'          log(window(AirPassengers, start=1957)))
+#' accuracy(forecast(air.model, h = 48, lambda = NULL),
+#'          log(window(AirPassengers, start = 1957)))
 #'
 Arima <- function(y, order=c(0, 0, 0), seasonal=c(0, 0, 0), xreg=NULL, include.mean=TRUE,
                   include.drift=FALSE, include.constant=NULL, lambda=model$lambda, biasadj=FALSE,

--- a/R/baggedModel.R
+++ b/R/baggedModel.R
@@ -132,7 +132,7 @@ baggedETS <- function(y, bootstrapped_series=bld.mbb.bootstrap(y, 100), ...) {
 #' plot(fcast)
 #'
 #' \dontrun{
-#' fit2 <- baggedModel(WWWusage, fn="auto.arima")
+#' fit2 <- baggedModel(WWWusage, fn = "auto.arima")
 #' fcast2 <- forecast(fit2)
 #' plot(fcast2)
 #' accuracy(fcast2)

--- a/R/components.R
+++ b/R/components.R
@@ -17,17 +17,18 @@
 #' @keywords ts
 #' @examples
 #' plot(USAccDeaths)
-#' fit <- stl(USAccDeaths, s.window="periodic")
-#' lines(trendcycle(fit), col="red")
+#' fit <- stl(USAccDeaths, s.window = "periodic")
+#' lines(trendcycle(fit), col = "red")
 #'
 #' library(ggplot2)
 #' autoplot(cbind(
-#' 	    Data=USAccDeaths,
-#' 	    Seasonal=seasonal(fit),
-#'   	  Trend=trendcycle(fit),
-#' 	    Remainder=remainder(fit)),
-#'     facets=TRUE) +
-#'   ylab("") + xlab("Year")
+#'     Data = USAccDeaths,
+#'     Seasonal = seasonal(fit),
+#'     Trend = trendcycle(fit),
+#'     Remainder = remainder(fit)
+#'   ),
+#'   facets = TRUE) +
+#'  ylab("") + xlab("Year")
 #'
 #' @export
 seasonal <- function(object) {

--- a/R/dshw.r
+++ b/R/dshw.r
@@ -71,8 +71,8 @@
 #' fcast <- dshw(taylor)
 #' plot(fcast)
 #'
-#' t <- seq(0, 5, by=1/20)
-#' x <- exp(sin(2*pi*t) + cos(2*pi*t*4) + rnorm(length(t), 0, .1))
+#' t <- seq(0, 5, by = 1 / 20)
+#' x <- exp(sin(2 * pi * t) + cos(2 * pi * t * 4) + rnorm(length(t), 0, 0.1))
 #' fit <- dshw(x, 20, 5)
 #' plot(fit)
 #' }

--- a/R/ets.R
+++ b/R/ets.R
@@ -1280,7 +1280,7 @@ admissible <- function(alpha, beta, gamma, phi, m) {
 #'
 #' fit <- ets(USAccDeaths)
 #' plot(fit)
-#' plot(fit, plot.type="single", ylab="", col=1:3)
+#' plot(fit, plot.type = "single", ylab = "", col = 1:3)
 #'
 #' library(ggplot2)
 #' autoplot(fit)

--- a/R/etsforecast.R
+++ b/R/etsforecast.R
@@ -48,7 +48,7 @@
 #' @keywords ts
 #' @examples
 #' fit <- ets(USAccDeaths)
-#' plot(forecast(fit, h=48))
+#' plot(forecast(fit, h = 48))
 #'
 #' @export forecast.ets
 #' @export

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -77,8 +77,8 @@
 #' @examples
 #'
 #' WWWusage %>% forecast %>% plot
-#' fit <- ets(window(WWWusage, end=60))
-#' fc <- forecast(WWWusage, model=fit)
+#' fit <- ets(window(WWWusage, end = 60))
+#' fc <- forecast(WWWusage, model = fit)
 #' @export
 forecast.ts <- function(object, h=ifelse(frequency(object) > 1, 2 * frequency(object), 10),
                         level=c(80, 95), fan=FALSE, robust=FALSE, lambda = NULL, biasadj = FALSE, find.frequency = FALSE,
@@ -277,12 +277,12 @@ plotlmforecast <- function(object, PI, shaded, shadecols, col, fcol, pi.col, pi.
 #' @examples
 #' library(ggplot2)
 #'
-#' wine.fit <- hw(wineind, h=48)
+#' wine.fit <- hw(wineind, h = 48)
 #' plot(wine.fit)
 #' autoplot(wine.fit)
 #'
 #' fit <- tslm(wineind ~ fourier(wineind, 4))
-#' fcast <- forecast(fit, newdata=data.frame(fourier(wineind, 4, 20)))
+#' fcast <- forecast(fit, newdata = data.frame(fourier(wineind, 4, 20)))
 #' autoplot(fcast)
 #'
 #' @export

--- a/R/forecast2.R
+++ b/R/forecast2.R
@@ -49,7 +49,7 @@
 #' @seealso \code{\link{rwf}}
 #' @keywords ts
 #' @examples
-#' nile.fcast <- meanf(Nile, h=10)
+#' nile.fcast <- meanf(Nile, h = 10)
 #' plot(nile.fcast)
 #'
 #' @export
@@ -158,7 +158,7 @@ meanf <- function(y, h=10, level=c(80, 95), fan=FALSE, lambda=NULL, biasadj=FALS
 #'
 #' lambda <- BoxCox.lambda(lynx)
 #' lynx.fit <- ar(BoxCox(lynx, lambda))
-#' plot(forecast(lynx.fit, h=20, lambda=lambda))
+#' plot(forecast(lynx.fit, h = 20, lambda = lambda))
 #'
 #' @export
 BoxCox <- function(x, lambda) {
@@ -407,7 +407,7 @@ forecast.StructTS <- function(object, h=ifelse(object$coef["epsilon"] > 1e-10, 2
 #' \code{\link[stats]{HoltWinters}}.
 #' @keywords ts
 #' @examples
-#' fit <- HoltWinters(WWWusage, gamma=FALSE)
+#' fit <- HoltWinters(WWWusage, gamma = FALSE)
 #' plot(forecast(fit))
 #'
 #' @export
@@ -523,7 +523,7 @@ forecast.HoltWinters <- function(object, h=ifelse(frequency(object$x) > 1, 2 * f
 #' Forecasting}, \bold{24}, 389-402.
 #' @keywords ts
 #' @examples
-#' y <- rpois(20, lambda=.3)
+#' y <- rpois(20, lambda = 0.3)
 #' fcast <- croston(y)
 #' plot(fcast)
 #'

--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -92,9 +92,9 @@ ggtsbreaks <- function(x) {
 #'
 #' library(ggplot2)
 #' ggAcf(wineind)
-#' wineind %>% Acf(plot=FALSE) %>% autoplot
+#' wineind %>% Acf(plot = FALSE) %>% autoplot
 #' \dontrun{
-#' wineind %>% taperedacf(plot=FALSE) %>% autoplot
+#' wineind %>% taperedacf(plot = FALSE) %>% autoplot
 #' ggtaperedacf(wineind)
 #' ggtaperedpacf(wineind)
 #' }
@@ -832,7 +832,7 @@ autoplot.mforecast <- function(object, PI = TRUE, facets = TRUE, colour = FALSE,
 #'
 #' @examples
 #' library(ggplot2)
-#' ggtsdisplay(USAccDeaths, plot.type="scatter", theme=theme_bw())
+#' ggtsdisplay(USAccDeaths, plot.type = "scatter", theme = theme_bw())
 #'
 #' @export
 ggtsdisplay <- function(x, plot.type=c("partial", "histogram", "scatter", "spectrum"),
@@ -983,11 +983,11 @@ ggtsdisplay <- function(x, plot.type=c("partial", "histogram", "scatter", "spect
 #' @examples
 #'
 #' gglagplot(woolyrnq)
-#' gglagplot(woolyrnq, seasonal=FALSE)
+#' gglagplot(woolyrnq, seasonal = FALSE)
 #'
 #' lungDeaths <- cbind(mdeaths, fdeaths)
-#' gglagplot(lungDeaths, lags=2)
-#' gglagchull(lungDeaths, lags=6)
+#' gglagplot(lungDeaths, lags = 2)
+#' gglagchull(lungDeaths, lags = 6)
 #'
 #' @export
 gglagplot <- function(x, lags=ifelse(frequency(x) > 9, 16, 9),
@@ -1295,8 +1295,8 @@ ggsubseriesplot <- function(x, labels = NULL, times = time(x), phase = cycle(x),
 #' @param polar Plot the graph on seasonal coordinates
 #'
 #' @examples
-#' ggseasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
-#' ggseasonplot(AirPassengers, year.labels=TRUE, continuous=TRUE)
+#' ggseasonplot(AirPassengers, col = rainbow(12), year.labels = TRUE)
+#' ggseasonplot(AirPassengers, year.labels = TRUE, continuous = TRUE)
 #'
 #' @export
 ggseasonplot <- function(x, season.labels=NULL, year.labels=FALSE, year.labels.left=FALSE, type=NULL, col=NULL, continuous=FALSE, polar=FALSE, labelgap=0.04, ...) {
@@ -1821,7 +1821,7 @@ autolayer.mforecast <- function(object, series = NULL, PI = TRUE, ...) {
 #'
 #' lungDeaths <- cbind(mdeaths, fdeaths)
 #' autoplot(lungDeaths)
-#' autoplot(lungDeaths, facets=TRUE)
+#' autoplot(lungDeaths, facets = TRUE)
 #'
 #' @export
 autoplot.ts <- function(object, series=NULL, xlab = "Time", ylab = deparse(substitute(object)),
@@ -2270,24 +2270,25 @@ GeomForecastInterval <- ggplot2::ggproto(
 #' autoplot(lungDeaths) + geom_forecast()
 #'
 #' # Using fortify.ts
-#' p <- ggplot(aes(x=x, y=y), data=USAccDeaths)
+#' p <- ggplot(aes(x = x, y = y), data = USAccDeaths)
 #' p <- p + geom_line()
 #' p + geom_forecast()
 #'
 #' # Without fortify.ts
-#' data <- data.frame(USAccDeaths=as.numeric(USAccDeaths), time=as.numeric(time(USAccDeaths)))
-#' p <- ggplot(aes(x=time, y=USAccDeaths), data=data)
+#' data <- data.frame(USAccDeaths = as.numeric(USAccDeaths),
+#'                    time = as.numeric(time(USAccDeaths)))
+#' p <- ggplot(aes(x = time, y = USAccDeaths), data = data)
 #' p <- p + geom_line()
 #' p + geom_forecast()
 #'
-#' p + geom_forecast(h=60)
-#' p <- ggplot(aes(x=time, y=USAccDeaths), data=data)
-#' p + geom_forecast(level=c(70, 98))
-#' p + geom_forecast(level=c(70, 98), colour="lightblue")
+#' p + geom_forecast(h = 60)
+#' p <- ggplot(aes(x = time, y = USAccDeaths), data = data)
+#' p + geom_forecast(level = c(70, 98))
+#' p + geom_forecast(level = c(70, 98), colour = "lightblue")
 #'
 #' #Add forecasts to multivariate series with colour groups
 #' lungDeaths <- cbind(mdeaths, fdeaths)
-#' autoplot(lungDeaths) + geom_forecast(forecast(mdeaths), series="mdeaths")
+#' autoplot(lungDeaths) + geom_forecast(forecast(mdeaths), series = "mdeaths")
 #' }
 #'
 #' @export
@@ -2347,7 +2348,7 @@ geom_forecast <- function(mapping = NULL, data = NULL, stat = "forecast",
 #' @seealso \code{\link[graphics]{hist}}, \code{\link[ggplot2]{geom_histogram}}
 #' @examples
 #'
-#' gghistogram(lynx, add.kde=TRUE)
+#' gghistogram(lynx, add.kde = TRUE)
 #'
 #' @export
 gghistogram <- function(x, add.normal=FALSE, add.kde=FALSE, add.rug=TRUE, bins, boundary=0) {

--- a/R/graph.R
+++ b/R/graph.R
@@ -39,7 +39,7 @@
 #' @keywords ts
 #' @examples
 #' tsdisplay(diff(WWWusage))
-#' ggtsdisplay(USAccDeaths, plot.type="scatter")
+#' ggtsdisplay(USAccDeaths, plot.type = "scatter")
 #'
 #' @export
 tsdisplay <- function(x, plot.type=c("partial", "histogram", "scatter", "spectrum"), points=TRUE, ci.type=c("white", "ma"),
@@ -128,7 +128,7 @@ tsdisplay <- function(x, plot.type=c("partial", "histogram", "scatter", "spectru
 #' \url{https://otexts.com/fpp2/}
 #' @keywords ts
 #' @examples
-#' seasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
+#' seasonplot(AirPassengers, col = rainbow(12), year.labels = TRUE)
 #'
 #' @export
 seasonplot <- function(x, s, season.labels=NULL, year.labels=FALSE, year.labels.left=FALSE,

--- a/R/guerrero.R
+++ b/R/guerrero.R
@@ -91,9 +91,11 @@ bcloglik <- function(x, lower=-1, upper=2) {
 #' @keywords ts
 #' @examples
 #'
-#' lambda <- BoxCox.lambda(AirPassengers, lower=0)
-#' air.fit <- Arima(AirPassengers, order=c(0, 1, 1),
-#'                  seasonal=list(order=c(0, 1, 1), period=12), lambda=lambda)
+#' lambda <- BoxCox.lambda(AirPassengers, lower = 0)
+#' air.fit <- Arima(AirPassengers,
+#'                  order = c(0, 1, 1),
+#'                  seasonal = list(order = c(0, 1, 1), period = 12),
+#'                  lambda = lambda)
 #' plot(forecast(air.fit))
 #'
 #' @export

--- a/R/lm.R
+++ b/R/lm.R
@@ -27,9 +27,9 @@
 #' @keywords stats
 #' @examples
 #'
-#' y <- ts(rnorm(120, 0, 3) + 1:120 + 20*sin(2*pi*(1:120)/12), frequency=12)
+#' y <- ts(rnorm(120, 0, 3) + 1:120 + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 #' fit <- tslm(y ~ trend + season)
-#' plot(forecast(fit, h=20))
+#' plot(forecast(fit, h = 20))
 #'
 #' @export
 tslm <- function(formula, data, subset, lambda=NULL, biasadj=FALSE, ...) {
@@ -235,9 +235,9 @@ fitted.tslm <- function(object, ...){
 #' @keywords stats
 #' @examples
 #'
-#' y <- ts(rnorm(120,0,3) + 1:120 + 20*sin(2*pi*(1:120)/12), frequency=12)
+#' y <- ts(rnorm(120, 0, 3) + 1:120 + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 #' fit <- tslm(y ~ trend + season)
-#' plot(forecast(fit, h=20))
+#' plot(forecast(fit, h = 20))
 #'
 #' @export
 forecast.lm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambda=object$lambda, biasadj=NULL, ts=TRUE, ...) {
@@ -510,7 +510,7 @@ summary.tslm <- function(object, ...) {
 #' @keywords models
 #' @examples
 #'
-#' y <- ts(rnorm(120,0,3) + 20*sin(2*pi*(1:120)/12), frequency=12)
+#' y <- ts(rnorm(120, 0, 3) + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 #' fit1 <- tslm(y ~ trend + season)
 #' fit2 <- tslm(y ~ season)
 #' CV(fit1)

--- a/R/mforecast.R
+++ b/R/mforecast.R
@@ -85,12 +85,12 @@ mlmsplit <- function(x, index=NULL) {
 #'
 #' lungDeaths <- cbind(mdeaths, fdeaths)
 #' fit <- tslm(lungDeaths ~ trend + season)
-#' fcast <- forecast(fit, h=10)
+#' fcast <- forecast(fit, h = 10)
 #'
-#' carPower <- as.matrix(mtcars[, c("qsec","hp")])
+#' carPower <- as.matrix(mtcars[, c("qsec", "hp")])
 #' carmpg <- mtcars[, "mpg"]
 #' fit <- lm(carPower ~ carmpg)
-#' fcast <- forecast(fit, newdata=data.frame(carmpg=30))
+#' fcast <- forecast(fit, newdata = data.frame(carmpg = 30))
 #'
 #' @export
 forecast.mlm <- function(object, newdata, h=10, level=c(80, 95), fan=FALSE, lambda=object$lambda, biasadj=NULL, ts=TRUE, ...) {
@@ -220,16 +220,16 @@ print.mforecast <- function(x, ...) {
 #'
 #' lungDeaths <- cbind(mdeaths, fdeaths)
 #' fit <- tslm(lungDeaths ~ trend + season)
-#' fcast <- forecast(fit, h=10)
+#' fcast <- forecast(fit, h = 10)
 #' plot(fcast)
 #' autoplot(fcast)
 #'
-#' carPower <- as.matrix(mtcars[, c("qsec","hp")])
+#' carPower <- as.matrix(mtcars[, c("qsec", "hp")])
 #' carmpg <- mtcars[, "mpg"]
 #' fit <- lm(carPower ~ carmpg)
-#' fcast <- forecast(fit, newdata=data.frame(carmpg=30))
-#' plot(fcast, xlab="Year")
-#' autoplot(fcast, xlab=rep("Year", 2))
+#' fcast <- forecast(fit, newdata = data.frame(carmpg = 30))
+#' plot(fcast, xlab = "Year")
+#' autoplot(fcast, xlab = rep("Year", 2))
 #'
 #' @export
 plot.mforecast <- function(x, main=paste("Forecasts from", unique(x$method)), xlab="time", ...) {

--- a/R/msts.R
+++ b/R/msts.R
@@ -23,8 +23,8 @@
 #' @keywords ts
 #' @examples
 #'
-#' x <- msts(taylor, seasonal.periods=c(2*24, 2*24*7, 2*24*365), start=2000+22/52)
-#' y <- msts(USAccDeaths, seasonal.periods=12, start=1949)
+#' x <- msts(taylor, seasonal.periods = c(2 * 24, 2 * 24 * 7, 2 * 24 * 365), start = 2000 + 22 / 52)
+#' y <- msts(USAccDeaths, seasonal.periods = 12, start = 1949)
 #'
 #' @export
 msts <- function(data, seasonal.periods, ts.frequency=floor(max(seasonal.periods)), ...) {

--- a/R/naive.R
+++ b/R/naive.R
@@ -164,7 +164,7 @@ fitted.lagwalk <- function(object, ...){
 #'
 #' @examples
 #'
-#' gold.fcast <- rwf(gold[1:60], h=50)
+#' gold.fcast <- rwf(gold[1:60], h = 50)
 #' plot(gold.fcast)
 #'
 #' @export
@@ -256,7 +256,7 @@ rwf <- function(y, h=10, drift=FALSE, level=c(80, 95), fan=FALSE, lambda=NULL, b
 #' @keywords ts
 #' @examples
 #'
-#' plot(naive(gold, h=50), include=200)
+#' plot(naive(gold, h = 50), include = 200)
 #'
 #' @export
 naive <- function(y, h=10, level=c(80, 95), fan=FALSE, lambda=NULL, biasadj=FALSE,

--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -90,7 +90,7 @@
 #' @keywords ts
 #' @examples
 #' fit <- auto.arima(WWWusage)
-#' plot(forecast(fit, h=20))
+#' plot(forecast(fit, h = 20))
 #'
 #' @export
 auto.arima <- function(y, d=NA, D=NA, max.p=5, max.q=5,

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -83,17 +83,17 @@
 #' plot(fcast)
 #'
 #' ## Arguments can be passed to nnet()
-#' fit <- nnetar(lynx, decay=0.5, maxit=150)
+#' fit <- nnetar(lynx, decay = 0.5, maxit = 150)
 #' plot(forecast(fit))
 #' lines(lynx)
 #'
 #' ## Fit model to first 100 years of lynx data
-#' fit <- nnetar(window(lynx, end=1920), decay=0.5, maxit=150)
-#' plot(forecast(fit, h=14))
+#' fit <- nnetar(window(lynx, end = 1920), decay = 0.5, maxit = 150)
+#' plot(forecast(fit, h = 14))
 #' lines(lynx)
 #'
 #' ## Apply fitted model to later data, including all optional arguments
-#' fit2 <- nnetar(window(lynx, start=1921), model=fit)
+#' fit2 <- nnetar(window(lynx, start = 1921), model = fit)
 #'
 #' @export
 nnetar <- function(y, p, P=1, size, repeats=20, xreg=NULL, lambda=NULL, model=NULL, subset=NULL, scale.inputs=TRUE, x=y, ...) {
@@ -447,21 +447,21 @@ print.nnetarmodels <- function(x, ...) {
 #' @keywords ts
 #' @examples
 #' ## Fit & forecast model
-#' fit <- nnetar(USAccDeaths, size=2)
-#' fcast <- forecast(fit, h=20)
+#' fit <- nnetar(USAccDeaths, size = 2)
+#' fcast <- forecast(fit, h = 20)
 #' plot(fcast)
 #'
 #' \dontrun{
 #' ## Include prediction intervals in forecast
-#' fcast2 <- forecast(fit, h=20, PI=TRUE, npaths=100)
+#' fcast2 <- forecast(fit, h = 20, PI = TRUE, npaths = 100)
 #' plot(fcast2)
 #'
 #' ## Set up out-of-sample innovations using cross-validation
-#' fit_cv <- CVar(USAccDeaths, size=2)
-#' res_sd <- sd(fit_cv$residuals, na.rm=TRUE)
-#' myinnovs <- rnorm(20*100, mean=0, sd=res_sd)
+#' fit_cv <- CVar(USAccDeaths, size = 2)
+#' res_sd <- sd(fit_cv$residuals, na.rm = TRUE)
+#' myinnovs <- rnorm(20 * 100, mean = 0, sd = res_sd)
 #' ## Forecast using new innovations
-#' fcast3 <- forecast(fit, h=20, PI=TRUE, npaths=100, innov=myinnovs)
+#' fcast3 <- forecast(fit, h = 20, PI = TRUE, npaths = 100, innov = myinnovs)
 #' plot(fcast3)
 #' }
 

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -53,10 +53,10 @@ residuals.ar <- function(object, type=c("innovation", "response"), ...) {
 #'
 #' @aliases residuals.forecast_ARIMA
 #' @examples
-#' fit <- Arima(lynx, order=c(4, 0, 0), lambda=0.5)
+#' fit <- Arima(lynx, order = c(4, 0, 0), lambda = 0.5)
 #'
 #' plot(residuals(fit))
-#' plot(residuals(fit, type="response"))
+#' plot(residuals(fit, type = "response"))
 #' @export
 residuals.Arima <- function(object, type=c("innovation", "response", "regression"), h=1, ...) {
   type <- match.arg(type)

--- a/R/seasadj.R
+++ b/R/seasadj.R
@@ -17,7 +17,7 @@
 #' @keywords ts
 #' @examples
 #' plot(AirPassengers)
-#' lines(seasadj(decompose(AirPassengers, "multiplicative")), col=4)
+#' lines(seasadj(decompose(AirPassengers, "multiplicative")), col = 4)
 #'
 #' @export
 seasadj <- function(object, ...) UseMethod("seasadj")

--- a/R/season.R
+++ b/R/season.R
@@ -13,12 +13,12 @@
 #' @keywords ts
 #' @examples
 #'
-#' par(mfrow=c(2, 1))
-#' plot(ldeaths, xlab="Year", ylab="pounds",
-#'      main="Monthly deaths from lung disease (UK)")
-#' ldeaths.adj <- ldeaths/monthdays(ldeaths)*365.25/12
-#' plot(ldeaths.adj, xlab="Year", ylab="pounds",
-#'      main="Adjusted monthly deaths from lung disease (UK)")
+#' par(mfrow = c(2, 1))
+#' plot(ldeaths, xlab = "Year", ylab = "pounds",
+#'      main = "Monthly deaths from lung disease (UK)")
+#' ldeaths.adj <- ldeaths / monthdays(ldeaths) * 365.25 / 12
+#' plot(ldeaths.adj, xlab = "Year", ylab = "pounds",
+#'      main = "Adjusted monthly deaths from lung disease (UK)")
 #'
 #' @export
 monthdays <- function(x) {
@@ -67,7 +67,7 @@ monthdays <- function(x) {
 #' uk.fcast$lower <- uk.fcast$lower + cbind(seasf, seasf)
 #' uk.fcast$upper <- uk.fcast$upper + cbind(seasf, seasf)
 #' uk.fcast$x <- UKDriverDeaths
-#' plot(uk.fcast, main="Forecasts from Holt's method with seasonal adjustment")
+#' plot(uk.fcast, main = "Forecasts from Holt's method with seasonal adjustment")
 #'
 #' @export
 sindexf <- function(object, h) {
@@ -121,15 +121,15 @@ sindexf <- function(object, h) {
 #'
 #' # Using seasonal dummy variables
 #' month <- seasonaldummy(ldeaths)
-#' deaths.lm  <- tslm(ldeaths ~ month)
+#' deaths.lm <- tslm(ldeaths ~ month)
 #' tsdisplay(residuals(deaths.lm))
 #' ldeaths.fcast <- forecast(deaths.lm,
-#'     data.frame(month=I(seasonaldummy(ldeaths, 36))))
+#'                           data.frame(month = I(seasonaldummy(ldeaths, 36))))
 #' plot(ldeaths.fcast)
 #'
 #' # A simpler approach to seasonal dummy variables
-#' deaths.lm  <- tslm(ldeaths ~ season)
-#' ldeaths.fcast <- forecast(deaths.lm, h=36)
+#' deaths.lm <- tslm(ldeaths ~ season)
+#' ldeaths.fcast <- forecast(deaths.lm, h = 36)
 #' plot(ldeaths.fcast)
 #'
 #' @export
@@ -215,14 +215,17 @@ seasonaldummyf <- function(x, h) {
 #'
 #' # Using Fourier series for a "ts" object
 #' # K is chosen to minimize the AICc
-#' deaths.model  <- auto.arima(USAccDeaths, xreg=fourier(USAccDeaths, K=5), seasonal=FALSE)
-#' deaths.fcast <- forecast(deaths.model, xreg=fourier(USAccDeaths, K=5, h=36))
+#' deaths.model <- auto.arima(USAccDeaths,
+#'                            xreg = fourier(USAccDeaths, K = 5),
+#'                            seasonal = FALSE)
+#' deaths.fcast <- forecast(deaths.model,
+#'                          xreg = fourier(USAccDeaths, K = 5, h = 36))
 #' autoplot(deaths.fcast) + xlab("Year")
 #'
 #' # Using Fourier series for a "msts" object
 #' taylor.lm <- tslm(taylor ~ fourier(taylor, K = c(3, 3)))
 #' taylor.fcast <- forecast(taylor.lm,
-#'     data.frame(fourier(taylor, K = c(3, 3), h = 270)))
+#'                          data.frame(fourier(taylor, K = c(3, 3), h = 270)))
 #' autoplot(taylor.fcast)
 #'
 #' @export
@@ -335,8 +338,8 @@ fourierf <- function(x, K, h) {
 #' @examples
 #'
 #' plot(wineind)
-#' sm <- ma(wineind, order=12)
-#' lines(sm, col="red")
+#' sm <- ma(wineind, order = 12)
+#' lines(sm, col = "red")
 #'
 #' @export
 ma <- function(x, order, centre=TRUE) {

--- a/R/spline.R
+++ b/R/spline.R
@@ -93,7 +93,7 @@ spline.loglik <- function(beta, y, cc=1e2) {
 #' \url{https://robjhyndman.com/publications/splinefcast/}.
 #' @keywords ts
 #' @examples
-#' fcast <- splinef(uspop, h=5)
+#' fcast <- splinef(uspop, h = 5)
 #' plot(fcast)
 #' summary(fcast)
 #'
@@ -215,7 +215,7 @@ splinef <- function(y, h=10, level=c(80, 95), fan=FALSE, lambda=NULL, biasadj=FA
 #' @rdname plot.forecast
 #'
 #' @examples
-#' fcast <- splinef(airmiles, h=5)
+#' fcast <- splinef(airmiles, h = 5)
 #' plot(fcast)
 #' autoplot(fcast)
 #'

--- a/R/subset.R
+++ b/R/subset.R
@@ -30,9 +30,9 @@
 #' @seealso \code{\link[base]{subset}}, \code{\link[stats]{window}}
 #' @keywords ts
 #' @examples
-#' plot(subset(gas, month="November"))
-#' subset(woolyrnq, quarter=3)
-#' subset(USAccDeaths, start=49)
+#' plot(subset(gas, month = "November"))
+#' subset(woolyrnq, quarter = 3)
+#' subset(USAccDeaths, start = 49)
 #'
 #' @export
 subset.ts <- function(x, subset=NULL, month=NULL, quarter=NULL, season=NULL,

--- a/R/tbats.R
+++ b/R/tbats.R
@@ -681,7 +681,7 @@ plot.tbats <- function(x, main="Decomposition by TBATS model", ...) {
 #' @examples
 #'
 #' \dontrun{
-#' fit <- tbats(USAccDeaths, use.parallel=FALSE)
+#' fit <- tbats(USAccDeaths, use.parallel = FALSE)
 #' components <- tbats.components(fit)
 #' plot(components)
 #' }

--- a/R/tscv.R
+++ b/R/tscv.R
@@ -42,20 +42,20 @@
 #' @examples
 #'
 #' #Fit an AR(2) model to each rolling origin subset
-#' far2 <- function(x, h) forecast(Arima(x, order=c(2, 0, 0)), h=h)
-#' e <- tsCV(lynx, far2, h=1)
+#' far2 <- function(x, h) forecast(Arima(x, order = c(2, 0, 0)), h = h)
+#' e <- tsCV(lynx, far2, h = 1)
 #'
 #' #Fit the same model with a rolling window of length 30
-#' e <- tsCV(lynx, far2, h=1, window=30)
+#' e <- tsCV(lynx, far2, h = 1, window = 30)
 #'
 #' #Example with exogenous predictors
 #' far2_xreg <- function(x, h, xreg, newxreg) {
-#'   forecast(Arima(x, order=c(2, 0, 0), xreg=xreg), xreg=newxreg)
+#'   forecast(Arima(x, order = c(2, 0, 0), xreg = xreg), xreg = newxreg)
 #' }
 #'
 #' y <- ts(rnorm(50))
-#' xreg <- matrix(rnorm(100), ncol=2)
-#' e <- tsCV(y, far2_xreg, h=3, xreg=xreg)
+#' xreg <- matrix(rnorm(100), ncol = 2)
+#' e <- tsCV(y, far2_xreg, h = 3, xreg = xreg)
 #'
 #' @export
 tsCV <- function(y, forecastfunction, h=1, window=NULL, xreg=NULL, initial=0, ...) {

--- a/README.md
+++ b/README.md
@@ -42,28 +42,28 @@ USAccDeaths |>
 # Automatic ARIMA forecasts
 WWWusage |>
   auto.arima() |>
-  forecast(h=20) |>
+  forecast(h = 20) |>
   autoplot()
 
 # ARFIMA forecasts
 library(fracdiff)
-x <- fracdiff.sim(100, ma=-.4, d=.3)$series
+x <- fracdiff.sim(100, ma = -0.4, d = 0.3)$series
 arfima(x) |>
-  forecast(h=30) |>
+  forecast(h = 30) |>
   autoplot()
 
 # Forecasting with STL
 USAccDeaths |>
-  stlm(modelfunction=ar) |>
-  forecast(h=36) |>
+  stlm(modelfunction = ar) |>
+  forecast(h = 36) |>
   autoplot()
 
 AirPassengers |>
-  stlf(lambda=0) |>
+  stlf(lambda = 0) |>
   autoplot()
 
 USAccDeaths |>
-  stl(s.window="periodic") |>
+  stl(s.window = "periodic") |>
   forecast() |>
   autoplot()
 

--- a/man/Acf.Rd
+++ b/man/Acf.Rd
@@ -114,8 +114,8 @@ autocovariance proposed by McMurry and Politis (2010).
 Acf(wineind)
 Pacf(wineind)
 \dontrun{
-taperedacf(wineind, nsim=50)
-taperedpacf(wineind, nsim=50)
+taperedacf(wineind, nsim = 50)
+taperedpacf(wineind, nsim = 50)
 }
 
 }

--- a/man/Arima.Rd
+++ b/man/Arima.Rd
@@ -103,18 +103,20 @@ Athanasopoulos (2018). For details of the estimation algorithm, see the
 \examples{
 library(ggplot2)
 WWWusage \%>\%
-  Arima(order=c(3, 1, 0)) \%>\%
-  forecast(h=20) \%>\%
+  Arima(order = c(3, 1, 0)) \%>\%
+  forecast(h = 20) \%>\%
   autoplot
 
 # Fit model to first few years of AirPassengers data
-air.model <- Arima(window(AirPassengers, end=1956+11/12), order=c(0, 1, 1),
-                   seasonal=list(order=c(0, 1, 1),period=12), lambda=0)
-plot(forecast(air.model, h=48))
+air.model <- Arima(window(AirPassengers, end = 1956 + 11 / 12),
+                   order = c(0, 1, 1),
+                   seasonal = list(order = c(0, 1, 1), period = 12),
+                   lambda = 0)
+plot(forecast(air.model, h = 48))
 lines(AirPassengers)
 
 # Apply fitted model to later data
-air.model2 <- Arima(window(AirPassengers, start=1957), model=air.model)
+air.model2 <- Arima(window(AirPassengers, start = 1957), model = air.model)
 
 # Forecast accuracy measures on the log scale.
 # in-sample one-step forecasts.
@@ -122,8 +124,8 @@ accuracy(air.model)
 # out-of-sample one-step forecasts.
 accuracy(air.model2)
 # out-of-sample multi-step forecasts
-accuracy(forecast(air.model, h=48, lambda=NULL),
-         log(window(AirPassengers, start=1957)))
+accuracy(forecast(air.model, h = 48, lambda = NULL),
+         log(window(AirPassengers, start = 1957)))
 
 }
 \references{

--- a/man/BoxCox.Rd
+++ b/man/BoxCox.Rd
@@ -45,7 +45,7 @@ if \eqn{\lambda\ne0}{lambda is not equal to 0}. For \eqn{\lambda=0}{lambda=0},
 
 lambda <- BoxCox.lambda(lynx)
 lynx.fit <- ar(BoxCox(lynx, lambda))
-plot(forecast(lynx.fit, h=20, lambda=lambda))
+plot(forecast(lynx.fit, h = 20, lambda = lambda))
 
 }
 \references{

--- a/man/BoxCox.lambda.Rd
+++ b/man/BoxCox.lambda.Rd
@@ -30,9 +30,11 @@ linear time trend with seasonal dummy variables is used.
 }
 \examples{
 
-lambda <- BoxCox.lambda(AirPassengers, lower=0)
-air.fit <- Arima(AirPassengers, order=c(0, 1, 1),
-                 seasonal=list(order=c(0, 1, 1), period=12), lambda=lambda)
+lambda <- BoxCox.lambda(AirPassengers, lower = 0)
+air.fit <- Arima(AirPassengers,
+                 order = c(0, 1, 1),
+                 seasonal = list(order = c(0, 1, 1), period = 12),
+                 lambda = lambda)
 plot(forecast(air.fit))
 
 }

--- a/man/CV.Rd
+++ b/man/CV.Rd
@@ -19,7 +19,7 @@ R^2 values for a linear model.
 }
 \examples{
 
-y <- ts(rnorm(120,0,3) + 20*sin(2*pi*(1:120)/12), frequency=12)
+y <- ts(rnorm(120, 0, 3) + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 fit1 <- tslm(y ~ trend + season)
 fit2 <- tslm(y ~ season)
 CV(fit1)

--- a/man/arfima.Rd
+++ b/man/arfima.Rd
@@ -73,7 +73,7 @@ the ARMA coefficients are refined using \code{\link[stats]{arima}}.
 \examples{
 
 library(fracdiff)
-x <- fracdiff.sim(100, ma=-.4, d=.3)$series
+x <- fracdiff.sim(100, ma = -0.4, d = 0.3)$series
 fit <- arfima(x)
 tsdisplay(residuals(fit))
 

--- a/man/auto.arima.Rd
+++ b/man/auto.arima.Rd
@@ -174,7 +174,7 @@ Hyndman and Khandakar (2008).
 }
 \examples{
 fit <- auto.arima(WWWusage)
-plot(forecast(fit, h=20))
+plot(forecast(fit, h = 20))
 
 }
 \references{

--- a/man/autoplot.acf.Rd
+++ b/man/autoplot.acf.Rd
@@ -110,9 +110,9 @@ ggtaperedpacf
 
 library(ggplot2)
 ggAcf(wineind)
-wineind \%>\% Acf(plot=FALSE) \%>\% autoplot
+wineind \%>\% Acf(plot = FALSE) \%>\% autoplot
 \dontrun{
-wineind \%>\% taperedacf(plot=FALSE) \%>\% autoplot
+wineind \%>\% taperedacf(plot = FALSE) \%>\% autoplot
 ggtaperedacf(wineind)
 ggtaperedpacf(wineind)
 }

--- a/man/autoplot.ts.Rd
+++ b/man/autoplot.ts.Rd
@@ -82,7 +82,7 @@ autoplot(USAccDeaths)
 
 lungDeaths <- cbind(mdeaths, fdeaths)
 autoplot(lungDeaths)
-autoplot(lungDeaths, facets=TRUE)
+autoplot(lungDeaths, facets = TRUE)
 
 }
 \seealso{

--- a/man/croston.Rd
+++ b/man/croston.Rd
@@ -50,7 +50,7 @@ Note that prediction intervals are not computed as Croston's method has no
 underlying stochastic model.
 }
 \examples{
-y <- rpois(20, lambda=.3)
+y <- rpois(20, lambda = 0.3)
 fcast <- croston(y)
 plot(fcast)
 

--- a/man/dshw.Rd
+++ b/man/dshw.Rd
@@ -98,8 +98,8 @@ from that in Taylor (2003); instead it matches that used in Hyndman et al
 fcast <- dshw(taylor)
 plot(fcast)
 
-t <- seq(0, 5, by=1/20)
-x <- exp(sin(2*pi*t) + cos(2*pi*t*4) + rnorm(length(t), 0, .1))
+t <- seq(0, 5, by = 1 / 20)
+x <- exp(sin(2 * pi * t) + cos(2 * pi * t * 4) + rnorm(length(t), 0, 0.1))
 fit <- dshw(x, 20, 5)
 plot(fit)
 }

--- a/man/forecast.HoltWinters.Rd
+++ b/man/forecast.HoltWinters.Rd
@@ -72,7 +72,7 @@ It is included for completeness, but the \code{\link{ets}} is recommended
 for use instead of \code{\link[stats]{HoltWinters}}.
 }
 \examples{
-fit <- HoltWinters(WWWusage, gamma=FALSE)
+fit <- HoltWinters(WWWusage, gamma = FALSE)
 plot(forecast(fit))
 
 }

--- a/man/forecast.baggedModel.Rd
+++ b/man/forecast.baggedModel.Rd
@@ -55,7 +55,7 @@ fcast <- forecast(fit)
 plot(fcast)
 
 \dontrun{
-fit2 <- baggedModel(WWWusage, fn="auto.arima")
+fit2 <- baggedModel(WWWusage, fn = "auto.arima")
 fcast2 <- forecast(fit2)
 plot(fcast2)
 accuracy(fcast2)

--- a/man/forecast.ets.Rd
+++ b/man/forecast.ets.Rd
@@ -84,7 +84,7 @@ Returns forecasts and other information for univariate ETS models.
 }
 \examples{
 fit <- ets(USAccDeaths)
-plot(forecast(fit, h=48))
+plot(forecast(fit, h = 48))
 
 }
 \seealso{

--- a/man/forecast.lm.Rd
+++ b/man/forecast.lm.Rd
@@ -83,9 +83,9 @@ characteristics of the data. Also, the output is reformatted into a
 }
 \examples{
 
-y <- ts(rnorm(120,0,3) + 1:120 + 20*sin(2*pi*(1:120)/12), frequency=12)
+y <- ts(rnorm(120, 0, 3) + 1:120 + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 fit <- tslm(y ~ trend + season)
-plot(forecast(fit, h=20))
+plot(forecast(fit, h = 20))
 
 }
 \seealso{

--- a/man/forecast.mlm.Rd
+++ b/man/forecast.mlm.Rd
@@ -85,12 +85,12 @@ generated on multiple series. Also, the output is reformatted into a
 
 lungDeaths <- cbind(mdeaths, fdeaths)
 fit <- tslm(lungDeaths ~ trend + season)
-fcast <- forecast(fit, h=10)
+fcast <- forecast(fit, h = 10)
 
-carPower <- as.matrix(mtcars[, c("qsec","hp")])
+carPower <- as.matrix(mtcars[, c("qsec", "hp")])
 carmpg <- mtcars[, "mpg"]
 fit <- lm(carPower ~ carmpg)
-fcast <- forecast(fit, newdata=data.frame(carmpg=30))
+fcast <- forecast(fit, newdata = data.frame(carmpg = 30))
 
 }
 \seealso{

--- a/man/forecast.nnetar.Rd
+++ b/man/forecast.nnetar.Rd
@@ -93,21 +93,21 @@ residuals to ameliorate this, see examples.
 }
 \examples{
 ## Fit & forecast model
-fit <- nnetar(USAccDeaths, size=2)
-fcast <- forecast(fit, h=20)
+fit <- nnetar(USAccDeaths, size = 2)
+fcast <- forecast(fit, h = 20)
 plot(fcast)
 
 \dontrun{
 ## Include prediction intervals in forecast
-fcast2 <- forecast(fit, h=20, PI=TRUE, npaths=100)
+fcast2 <- forecast(fit, h = 20, PI = TRUE, npaths = 100)
 plot(fcast2)
 
 ## Set up out-of-sample innovations using cross-validation
-fit_cv <- CVar(USAccDeaths, size=2)
-res_sd <- sd(fit_cv$residuals, na.rm=TRUE)
-myinnovs <- rnorm(20*100, mean=0, sd=res_sd)
+fit_cv <- CVar(USAccDeaths, size = 2)
+res_sd <- sd(fit_cv$residuals, na.rm = TRUE)
+myinnovs <- rnorm(20 * 100, mean = 0, sd = res_sd)
 ## Forecast using new innovations
-fcast3 <- forecast(fit, h=20, PI=TRUE, npaths=100, innov=myinnovs)
+fcast3 <- forecast(fit, h = 20, PI = TRUE, npaths = 100, innov = myinnovs)
 plot(fcast3)
 }
 

--- a/man/forecast.ts.Rd
+++ b/man/forecast.ts.Rd
@@ -115,8 +115,8 @@ accordingly.
 \examples{
 
 WWWusage \%>\% forecast \%>\% plot
-fit <- ets(window(WWWusage, end=60))
-fc <- forecast(WWWusage, model=fit)
+fit <- ets(window(WWWusage, end = 60))
+fc <- forecast(WWWusage, model = fit)
 }
 \seealso{
 Other functions which return objects of class \code{"forecast"} are

--- a/man/fourier.Rd
+++ b/man/fourier.Rd
@@ -53,14 +53,17 @@ library(ggplot2)
 
 # Using Fourier series for a "ts" object
 # K is chosen to minimize the AICc
-deaths.model  <- auto.arima(USAccDeaths, xreg=fourier(USAccDeaths, K=5), seasonal=FALSE)
-deaths.fcast <- forecast(deaths.model, xreg=fourier(USAccDeaths, K=5, h=36))
+deaths.model <- auto.arima(USAccDeaths,
+                           xreg = fourier(USAccDeaths, K = 5),
+                           seasonal = FALSE)
+deaths.fcast <- forecast(deaths.model,
+                         xreg = fourier(USAccDeaths, K = 5, h = 36))
 autoplot(deaths.fcast) + xlab("Year")
 
 # Using Fourier series for a "msts" object
 taylor.lm <- tslm(taylor ~ fourier(taylor, K = c(3, 3)))
 taylor.fcast <- forecast(taylor.lm,
-    data.frame(fourier(taylor, K = c(3, 3), h = 270)))
+                         data.frame(fourier(taylor, K = c(3, 3), h = 270)))
 autoplot(taylor.fcast)
 
 }

--- a/man/geom_forecast.Rd
+++ b/man/geom_forecast.Rd
@@ -109,24 +109,25 @@ lungDeaths <- cbind(mdeaths, fdeaths)
 autoplot(lungDeaths) + geom_forecast()
 
 # Using fortify.ts
-p <- ggplot(aes(x=x, y=y), data=USAccDeaths)
+p <- ggplot(aes(x = x, y = y), data = USAccDeaths)
 p <- p + geom_line()
 p + geom_forecast()
 
 # Without fortify.ts
-data <- data.frame(USAccDeaths=as.numeric(USAccDeaths), time=as.numeric(time(USAccDeaths)))
-p <- ggplot(aes(x=time, y=USAccDeaths), data=data)
+data <- data.frame(USAccDeaths = as.numeric(USAccDeaths),
+                   time = as.numeric(time(USAccDeaths)))
+p <- ggplot(aes(x = time, y = USAccDeaths), data = data)
 p <- p + geom_line()
 p + geom_forecast()
 
-p + geom_forecast(h=60)
-p <- ggplot(aes(x=time, y=USAccDeaths), data=data)
-p + geom_forecast(level=c(70, 98))
-p + geom_forecast(level=c(70, 98), colour="lightblue")
+p + geom_forecast(h = 60)
+p <- ggplot(aes(x = time, y = USAccDeaths), data = data)
+p + geom_forecast(level = c(70, 98))
+p + geom_forecast(level = c(70, 98), colour = "lightblue")
 
 #Add forecasts to multivariate series with colour groups
 lungDeaths <- cbind(mdeaths, fdeaths)
-autoplot(lungDeaths) + geom_forecast(forecast(mdeaths), series="mdeaths")
+autoplot(lungDeaths) + geom_forecast(forecast(mdeaths), series = "mdeaths")
 }
 
 }

--- a/man/gghistogram.Rd
+++ b/man/gghistogram.Rd
@@ -35,7 +35,7 @@ Plots a histogram and density estimates using ggplot.
 }
 \examples{
 
-gghistogram(lynx, add.kde=TRUE)
+gghistogram(lynx, add.kde = TRUE)
 
 }
 \seealso{

--- a/man/gglagplot.Rd
+++ b/man/gglagplot.Rd
@@ -71,11 +71,11 @@ plot. This helps visualise the change in 'auto-dependence' as lags increase.
 \examples{
 
 gglagplot(woolyrnq)
-gglagplot(woolyrnq, seasonal=FALSE)
+gglagplot(woolyrnq, seasonal = FALSE)
 
 lungDeaths <- cbind(mdeaths, fdeaths)
-gglagplot(lungDeaths, lags=2)
-gglagchull(lungDeaths, lags=6)
+gglagplot(lungDeaths, lags = 2)
+gglagchull(lungDeaths, lags = 6)
 
 gglagchull(woolyrnq)
 

--- a/man/ma.Rd
+++ b/man/ma.Rd
@@ -39,8 +39,8 @@ average.
 \examples{
 
 plot(wineind)
-sm <- ma(wineind, order=12)
-lines(sm, col="red")
+sm <- ma(wineind, order = 12)
+lines(sm, col = "red")
 
 }
 \seealso{

--- a/man/meanf.Rd
+++ b/man/meanf.Rd
@@ -81,7 +81,7 @@ where \eqn{Z_t}{Z[t]} is a normal iid error. Forecasts are given by
 where \eqn{\mu}{mu} is estimated by the sample mean.
 }
 \examples{
-nile.fcast <- meanf(Nile, h=10)
+nile.fcast <- meanf(Nile, h = 10)
 plot(nile.fcast)
 
 }

--- a/man/monthdays.Rd
+++ b/man/monthdays.Rd
@@ -20,12 +20,12 @@ Useful for month length adjustments
 }
 \examples{
 
-par(mfrow=c(2, 1))
-plot(ldeaths, xlab="Year", ylab="pounds",
-     main="Monthly deaths from lung disease (UK)")
-ldeaths.adj <- ldeaths/monthdays(ldeaths)*365.25/12
-plot(ldeaths.adj, xlab="Year", ylab="pounds",
-     main="Adjusted monthly deaths from lung disease (UK)")
+par(mfrow = c(2, 1))
+plot(ldeaths, xlab = "Year", ylab = "pounds",
+     main = "Monthly deaths from lung disease (UK)")
+ldeaths.adj <- ldeaths / monthdays(ldeaths) * 365.25 / 12
+plot(ldeaths.adj, xlab = "Year", ylab = "pounds",
+     main = "Adjusted monthly deaths from lung disease (UK)")
 
 }
 \seealso{

--- a/man/msts.Rd
+++ b/man/msts.Rd
@@ -36,8 +36,8 @@ class, should also work on a msts class.
 }
 \examples{
 
-x <- msts(taylor, seasonal.periods=c(2*24, 2*24*7, 2*24*365), start=2000+22/52)
-y <- msts(USAccDeaths, seasonal.periods=12, start=1949)
+x <- msts(taylor, seasonal.periods = c(2 * 24, 2 * 24 * 7, 2 * 24 * 365), start = 2000 + 22 / 52)
+y <- msts(USAccDeaths, seasonal.periods = 12, start = 1949)
 
 }
 \author{

--- a/man/naive.Rd
+++ b/man/naive.Rd
@@ -126,11 +126,11 @@ where \eqn{Z_t}{Z[t]} is a normal iid error.
 }
 \examples{
 
-gold.fcast <- rwf(gold[1:60], h=50)
+gold.fcast <- rwf(gold[1:60], h = 50)
 plot(gold.fcast)
 
 
-plot(naive(gold, h=50), include=200)
+plot(naive(gold, h = 50), include = 200)
 
 
 plot(snaive(wineind))

--- a/man/nnetar.Rd
+++ b/man/nnetar.Rd
@@ -110,17 +110,17 @@ fcast <- forecast(fit)
 plot(fcast)
 
 ## Arguments can be passed to nnet()
-fit <- nnetar(lynx, decay=0.5, maxit=150)
+fit <- nnetar(lynx, decay = 0.5, maxit = 150)
 plot(forecast(fit))
 lines(lynx)
 
 ## Fit model to first 100 years of lynx data
-fit <- nnetar(window(lynx, end=1920), decay=0.5, maxit=150)
-plot(forecast(fit, h=14))
+fit <- nnetar(window(lynx, end = 1920), decay = 0.5, maxit = 150)
+plot(forecast(fit, h = 14))
 lines(lynx)
 
 ## Apply fitted model to later data, including all optional arguments
-fit2 <- nnetar(window(lynx, start=1921), model=fit)
+fit2 <- nnetar(window(lynx, start = 1921), model = fit)
 
 }
 \author{

--- a/man/plot.ets.Rd
+++ b/man/plot.ets.Rd
@@ -35,7 +35,7 @@ model.
 
 fit <- ets(USAccDeaths)
 plot(fit)
-plot(fit, plot.type="single", ylab="", col=1:3)
+plot(fit, plot.type = "single", ylab = "", col = 1:3)
 
 library(ggplot2)
 autoplot(fit)

--- a/man/plot.forecast.Rd
+++ b/man/plot.forecast.Rd
@@ -119,15 +119,15 @@ plot.splineforecast autoplot.splineforecast
 \examples{
 library(ggplot2)
 
-wine.fit <- hw(wineind, h=48)
+wine.fit <- hw(wineind, h = 48)
 plot(wine.fit)
 autoplot(wine.fit)
 
 fit <- tslm(wineind ~ fourier(wineind, 4))
-fcast <- forecast(fit, newdata=data.frame(fourier(wineind, 4, 20)))
+fcast <- forecast(fit, newdata = data.frame(fourier(wineind, 4, 20)))
 autoplot(fcast)
 
-fcast <- splinef(airmiles, h=5)
+fcast <- splinef(airmiles, h = 5)
 plot(fcast)
 autoplot(fcast)
 

--- a/man/plot.mforecast.Rd
+++ b/man/plot.mforecast.Rd
@@ -48,16 +48,16 @@ library(ggplot2)
 
 lungDeaths <- cbind(mdeaths, fdeaths)
 fit <- tslm(lungDeaths ~ trend + season)
-fcast <- forecast(fit, h=10)
+fcast <- forecast(fit, h = 10)
 plot(fcast)
 autoplot(fcast)
 
-carPower <- as.matrix(mtcars[, c("qsec","hp")])
+carPower <- as.matrix(mtcars[, c("qsec", "hp")])
 carmpg <- mtcars[, "mpg"]
 fit <- lm(carPower ~ carmpg)
-fcast <- forecast(fit, newdata=data.frame(carmpg=30))
-plot(fcast, xlab="Year")
-autoplot(fcast, xlab=rep("Year", 2))
+fcast <- forecast(fit, newdata = data.frame(carmpg = 30))
+plot(fcast, xlab = "Year")
+autoplot(fcast, xlab = rep("Year", 2))
 
 }
 \references{

--- a/man/residuals.forecast.Rd
+++ b/man/residuals.forecast.Rd
@@ -71,10 +71,10 @@ For \code{nnetar} objects, when \code{type="innovations"} and \code{lambda} is u
 matrix of time-series consisting of the residuals from each of the fitted neural networks is returned.
 }
 \examples{
-fit <- Arima(lynx, order=c(4, 0, 0), lambda=0.5)
+fit <- Arima(lynx, order = c(4, 0, 0), lambda = 0.5)
 
 plot(residuals(fit))
-plot(residuals(fit, type="response"))
+plot(residuals(fit, type = "response"))
 }
 \seealso{
 \code{\link{fitted.Arima}}, \code{\link{checkresiduals}}.

--- a/man/seasadj.Rd
+++ b/man/seasadj.Rd
@@ -36,7 +36,7 @@ component.
 }
 \examples{
 plot(AirPassengers)
-lines(seasadj(decompose(AirPassengers, "multiplicative")), col=4)
+lines(seasadj(decompose(AirPassengers, "multiplicative")), col = 4)
 
 }
 \seealso{

--- a/man/seasonal.Rd
+++ b/man/seasonal.Rd
@@ -26,17 +26,18 @@ decomposition.
 }
 \examples{
 plot(USAccDeaths)
-fit <- stl(USAccDeaths, s.window="periodic")
-lines(trendcycle(fit), col="red")
+fit <- stl(USAccDeaths, s.window = "periodic")
+lines(trendcycle(fit), col = "red")
 
 library(ggplot2)
 autoplot(cbind(
-	    Data=USAccDeaths,
-	    Seasonal=seasonal(fit),
-  	  Trend=trendcycle(fit),
-	    Remainder=remainder(fit)),
-    facets=TRUE) +
-  ylab("") + xlab("Year")
+    Data = USAccDeaths,
+    Seasonal = seasonal(fit),
+    Trend = trendcycle(fit),
+    Remainder = remainder(fit)
+  ),
+  facets = TRUE) +
+ ylab("") + xlab("Year")
 
 }
 \seealso{

--- a/man/seasonaldummy.Rd
+++ b/man/seasonaldummy.Rd
@@ -39,15 +39,15 @@ plot(ldeaths)
 
 # Using seasonal dummy variables
 month <- seasonaldummy(ldeaths)
-deaths.lm  <- tslm(ldeaths ~ month)
+deaths.lm <- tslm(ldeaths ~ month)
 tsdisplay(residuals(deaths.lm))
 ldeaths.fcast <- forecast(deaths.lm,
-    data.frame(month=I(seasonaldummy(ldeaths, 36))))
+                          data.frame(month = I(seasonaldummy(ldeaths, 36))))
 plot(ldeaths.fcast)
 
 # A simpler approach to seasonal dummy variables
-deaths.lm  <- tslm(ldeaths ~ season)
-ldeaths.fcast <- forecast(deaths.lm, h=36)
+deaths.lm <- tslm(ldeaths ~ season)
+ldeaths.fcast <- forecast(deaths.lm, h = 36)
 plot(ldeaths.fcast)
 
 }

--- a/man/seasonplot.Rd
+++ b/man/seasonplot.Rd
@@ -75,10 +75,10 @@ chapter 2). This is like a time plot except that the data are plotted
 against the seasons in separate years.
 }
 \examples{
-ggseasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
-ggseasonplot(AirPassengers, year.labels=TRUE, continuous=TRUE)
+ggseasonplot(AirPassengers, col = rainbow(12), year.labels = TRUE)
+ggseasonplot(AirPassengers, year.labels = TRUE, continuous = TRUE)
 
-seasonplot(AirPassengers, col=rainbow(12), year.labels=TRUE)
+seasonplot(AirPassengers, col = rainbow(12), year.labels = TRUE)
 
 }
 \references{

--- a/man/ses.Rd
+++ b/man/ses.Rd
@@ -140,7 +140,7 @@ ses, holt and hw are simply convenient wrapper functions for
 
 fcast <- holt(airmiles)
 plot(fcast)
-deaths.fcast <- hw(USAccDeaths, h=48)
+deaths.fcast <- hw(USAccDeaths, h = 48)
 plot(deaths.fcast)
 
 }

--- a/man/sindexf.Rd
+++ b/man/sindexf.Rd
@@ -28,7 +28,7 @@ uk.fcast$mean <- uk.fcast$mean + seasf
 uk.fcast$lower <- uk.fcast$lower + cbind(seasf, seasf)
 uk.fcast$upper <- uk.fcast$upper + cbind(seasf, seasf)
 uk.fcast$x <- UKDriverDeaths
-plot(uk.fcast, main="Forecasts from Holt's method with seasonal adjustment")
+plot(uk.fcast, main = "Forecasts from Holt's method with seasonal adjustment")
 
 }
 \author{

--- a/man/splinef.Rd
+++ b/man/splinef.Rd
@@ -79,7 +79,7 @@ that the forecast performance of the method is hardly affected by the
 restricted parameter space.
 }
 \examples{
-fcast <- splinef(uspop, h=5)
+fcast <- splinef(uspop, h = 5)
 plot(fcast)
 summary(fcast)
 

--- a/man/subset.ts.Rd
+++ b/man/subset.ts.Rd
@@ -58,9 +58,9 @@ values for quarters are \code{"Q1"}, \code{"Q2"}, \code{"Q3"}, and
 \code{"Q4"}.
 }
 \examples{
-plot(subset(gas, month="November"))
-subset(woolyrnq, quarter=3)
-subset(USAccDeaths, start=49)
+plot(subset(gas, month = "November"))
+subset(woolyrnq, quarter = 3)
+subset(USAccDeaths, start = 49)
 
 }
 \seealso{

--- a/man/tbats.components.Rd
+++ b/man/tbats.components.Rd
@@ -18,7 +18,7 @@ Extract the level, slope and seasonal components of a TBATS model. The extracted
 \examples{
 
 \dontrun{
-fit <- tbats(USAccDeaths, use.parallel=FALSE)
+fit <- tbats(USAccDeaths, use.parallel = FALSE)
 components <- tbats.components(fit)
 plot(components)
 }

--- a/man/tsCV.Rd
+++ b/man/tsCV.Rd
@@ -50,20 +50,20 @@ series.
 \examples{
 
 #Fit an AR(2) model to each rolling origin subset
-far2 <- function(x, h) forecast(Arima(x, order=c(2, 0, 0)), h=h)
-e <- tsCV(lynx, far2, h=1)
+far2 <- function(x, h) forecast(Arima(x, order = c(2, 0, 0)), h = h)
+e <- tsCV(lynx, far2, h = 1)
 
 #Fit the same model with a rolling window of length 30
-e <- tsCV(lynx, far2, h=1, window=30)
+e <- tsCV(lynx, far2, h = 1, window = 30)
 
 #Example with exogenous predictors
 far2_xreg <- function(x, h, xreg, newxreg) {
-  forecast(Arima(x, order=c(2, 0, 0), xreg=xreg), xreg=newxreg)
+  forecast(Arima(x, order = c(2, 0, 0), xreg = xreg), xreg = newxreg)
 }
 
 y <- ts(rnorm(50))
-xreg <- matrix(rnorm(100), ncol=2)
-e <- tsCV(y, far2_xreg, h=3, xreg=xreg)
+xreg <- matrix(rnorm(100), ncol = 2)
+e <- tsCV(y, far2_xreg, h = 3, xreg = xreg)
 
 }
 \seealso{

--- a/man/tsdisplay.Rd
+++ b/man/tsdisplay.Rd
@@ -79,10 +79,10 @@ scatterplot or spectrum.
 }
 \examples{
 library(ggplot2)
-ggtsdisplay(USAccDeaths, plot.type="scatter", theme=theme_bw())
+ggtsdisplay(USAccDeaths, plot.type = "scatter", theme = theme_bw())
 
 tsdisplay(diff(WWWusage))
-ggtsdisplay(USAccDeaths, plot.type="scatter")
+ggtsdisplay(USAccDeaths, plot.type = "scatter")
 
 }
 \references{

--- a/man/tslm.Rd
+++ b/man/tslm.Rd
@@ -48,9 +48,9 @@ month or the quarter depending on the frequency of the data).
 }
 \examples{
 
-y <- ts(rnorm(120, 0, 3) + 1:120 + 20*sin(2*pi*(1:120)/12), frequency=12)
+y <- ts(rnorm(120, 0, 3) + 1:120 + 20 * sin(2 * pi * (1:120) / 12), frequency = 12)
 fit <- tslm(y ~ trend + season)
-plot(forecast(fit, h=20))
+plot(forecast(fit, h = 20))
 
 }
 \seealso{


### PR DESCRIPTION
@robjhyndman see if you like this, this consistently adds whitespace around infix operators in the examples, like already done for a few examples.