### PR TITLE
perf: replace `is.element()` with `x %in% y`

### DIFF
--- a/R/arima.R
+++ b/R/arima.R
@@ -361,9 +361,9 @@ forecast.Arima <- function(
     ))
   }
 
-  use.drift <- is.element("drift", names(object$coef))
+  use.drift <- "drift" %in% names(object$coef)
   x <- object$x <- getResponse(object)
-  usexreg <- (use.drift || is.element("xreg", names(object))) # | use.constant)
+  usexreg <- (use.drift || "xreg" %in% names(object)) # | use.constant)
 
   if (!is.null(xreg) && usexreg) {
     if (!is.numeric(xreg)) {
@@ -619,17 +619,17 @@ forecast.ar <- function(
 
 getxreg <- function(z) {
   # Look in the obvious place first
-  if (is.element("xreg", names(z))) {
+  if ("xreg" %in% names(z)) {
     return(z$xreg)
-  } else if (is.element("xreg", names(z$coef))) {
+  } else if ("xreg" %in% names(z$coef)) {
     # Next most obvious place
     return(eval.parent(z$coef$xreg))
-  } else if (is.element("xreg", names(z$call))) {
+  } else if ("xreg" %in% names(z$call)) {
     # Now check under call
     return(eval.parent(z$call$xreg))
   } else {
     # Otherwise check if it exists
-    armapar <- sum(z$arma[1:4]) + is.element("intercept", names(z$coef))
+    armapar <- sum(z$arma[1:4]) + "intercept" %in% names(z$coef)
     npar <- length(z$coef)
     if (npar > armapar) {
       stop(
@@ -962,9 +962,9 @@ Arima <- function(
 
 # Refits the model to new data x
 arima2 <- function(x, model, xreg, method) {
-  use.drift <- is.element("drift", names(model$coef))
-  use.intercept <- is.element("intercept", names(model$coef))
-  use.xreg <- is.element("xreg", names(model$call))
+  use.drift <- "drift" %in% names(model$coef)
+  use.intercept <- "intercept" %in% names(model$coef)
+  use.xreg <- "xreg" %in% names(model$call)
   sigma2 <- model$sigma2
   if (use.drift) {
     driftmod <- lm(model$xreg[, "drift"] ~ I(time(as.ts(model$x))))

--- a/R/errors.R
+++ b/R/errors.R
@@ -9,14 +9,14 @@ testaccuracy <- function(f, x, test, d, D) {
   dx <- getResponse(f)
   if (is.data.frame(x)) {
     responsevar <- as.character(formula(f$model))[2]
-    if (is.element(responsevar, colnames(x))) {
+    if (responsevar %in% colnames(x)) {
       x <- x[, responsevar]
     } else {
       stop("I can't figure out what data to use.")
     }
   }
   if (is.list(f)) {
-    if (is.element("mean", names(f))) {
+    if ("mean" %in% names(f)) {
       f <- f$mean
     } else {
       stop("Unknown list structure")

--- a/R/ets.R
+++ b/R/ets.R
@@ -280,13 +280,13 @@ ets <- function(
   trendtype <- substr(model, 2, 2)
   seasontype <- substr(model, 3, 3)
 
-  if (!is.element(errortype, c("M", "A", "Z"))) {
+  if (!errortype %in% c("M", "A", "Z")) {
     stop("Invalid error type")
   }
-  if (!is.element(trendtype, c("N", "A", "M", "Z"))) {
+  if (!trendtype %in% c("N", "A", "M", "Z")) {
     stop("Invalid trend type")
   }
-  if (!is.element(seasontype, c("N", "A", "M", "Z"))) {
+  if (!seasontype %in% c("N", "A", "M", "Z")) {
     stop("Invalid season type")
   }
 
@@ -302,7 +302,7 @@ ets <- function(
     }
   }
   if (m > 24) {
-    if (is.element(seasontype, c("A", "M"))) {
+    if (seasontype %in% c("A", "M")) {
       stop("Frequency too high")
     } else if (seasontype == "Z") {
       warning(

--- a/R/etsforecast.R
+++ b/R/etsforecast.R
@@ -115,8 +115,8 @@ forecast.ets <- function(
     )
   } else if (
     object$components[1] == "A" &&
-      is.element(object$components[2], c("A", "N")) &&
-      is.element(object$components[3], c("N", "A"))
+      object$components[2] %in% c("A", "N") &&
+      object$components[3] %in% c("N", "A")
   ) {
     f <- class1(
       h,
@@ -130,8 +130,8 @@ forecast.ets <- function(
     )
   } else if (
     object$components[1] == "M" &&
-      is.element(object$components[2], c("A", "N")) &&
-      is.element(object$components[3], c("N", "A"))
+      object$components[2] %in% c("A", "N") &&
+      object$components[3] %in% c("N", "A")
   ) {
     f <- class2(
       h,

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -387,7 +387,7 @@ plot.forecast <- function(
   flwd = 2,
   ...
 ) {
-  if (is.element("x", names(x))) {
+  if ("x" %in% names(x)) {
     # Assume stored as x
     xx <- x$x
   } else {

--- a/R/forecast2.R
+++ b/R/forecast2.R
@@ -210,9 +210,9 @@ forecast.StructTS <- function(
     upper[, i] <- pred$pred + qq * pred$se
   }
   colnames(lower) <- colnames(upper) <- paste0(level, "%")
-  if (is.element("seas", names(object$coef))) {
+  if ("seas" %in% names(object$coef)) {
     method <- "Basic structural model"
-  } else if (is.element("slope", names(object$coef))) {
+  } else if ("slope" %in% names(object$coef)) {
     method <- "Local linear structural model"
   } else {
     method <- "Local level structural model"

--- a/R/getResponse.R
+++ b/R/getResponse.R
@@ -43,7 +43,7 @@ getResponse.lm <- function(object, ...) {
 #' @rdname getResponse
 #' @export
 getResponse.Arima <- function(object, ...) {
-  if (is.element("x", names(object))) {
+  if ("x" %in% names(object)) {
     x <- object$x
   } else {
     series.name <- object$series
@@ -67,7 +67,7 @@ getResponse.Arima <- function(object, ...) {
 #' @rdname getResponse
 #' @export
 getResponse.fracdiff <- function(object, ...) {
-  if (is.element("x", names(object))) {
+  if ("x" %in% names(object)) {
     x <- object$x
   } else {
     series.name <- as.character(object$call)[2]
@@ -97,7 +97,7 @@ getResponse.ar <- function(object, ...) {
 #' @rdname getResponse
 #' @export
 getResponse.tbats <- function(object, ...) {
-  if (is.element("y", names(object))) {
+  if ("y" %in% names(object)) {
     y <- object$y
   } else {
     return(NULL)
@@ -120,7 +120,7 @@ getResponse.mforecast <- function(object, ...) {
 #' @rdname getResponse
 #' @export
 getResponse.baggedModel <- function(object, ...) {
-  if (is.element("y", names(object))) {
+  if ("y" %in% names(object)) {
     y <- object$y
   } else {
     return(NULL)

--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -1399,15 +1399,14 @@ arima.string <- function(object, padding = FALSE) {
     }
   }
   if (!is.null(object$xreg)) {
-    if (NCOL(object$xreg) == 1 && is.element("drift", names(object$coef))) {
+    if (NCOL(object$xreg) == 1 && "drift" %in% names(object$coef)) {
       result <- paste(result, "with drift        ")
     } else {
       result <- paste("Regression with", result, "errors")
     }
   } else {
     if (
-      is.element("constant", names(object$coef)) ||
-        is.element("intercept", names(object$coef))
+      "constant" %in% names(object$coef) || "intercept" %in% names(object$coef)
     ) {
       result <- paste(result, "with non-zero mean")
     } else if (order[2] == 0 && order[5] == 0) {

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -79,7 +79,7 @@ residuals.Arima <- function(
     }
     xreg <- getxreg(object)
     # Remove intercept
-    if (is.element("intercept", names(object$coef))) {
+    if ("intercept" %in% names(object$coef)) {
       xreg <- cbind(rep(1, length(x)), xreg)
     }
     # Return errors
@@ -159,7 +159,7 @@ residuals.ARFIMA <- function(object, type = c("innovation", "response"), ...) {
       return(object$residuals)
     } else {
       # Object produced by fracdiff()
-      if (is.element("x", names(object))) {
+      if ("x" %in% names(object)) {
         x <- object$x
       } else {
         x <- eval.parent(parse(text = as.character(object$call)[2]))

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -338,7 +338,7 @@ simulate.Arima <- function(
     xreg <- as.matrix(xreg)
     nsim <- nrow(xreg)
   }
-  use.drift <- is.element("drift", names(object$coef))
+  use.drift <- "drift" %in% names(object$coef)
   usexreg <- (!is.null(xreg) | use.drift | !is.null(object$xreg))
   xm <- oldxm <- 0
   if (use.drift) {

--- a/R/subset.R
+++ b/R/subset.R
@@ -118,11 +118,11 @@ subset.ts <- function(
     stop(paste("Seasons must be between 1 and", frequency(x)))
   }
 
-  start <- utils::head(time(x)[is.element(cycle(x), season)], 1)
+  start <- utils::head(time(x)[cycle(x) %in% season], 1)
   if (is.mts(x)) {
-    x <- subset.matrix(x, is.element(cycle(x), season))
+    x <- subset.matrix(x, cycle(x) %in% season)
   } else {
-    x <- subset.default(x, is.element(cycle(x), season))
+    x <- subset.default(x, cycle(x) %in% season)
   }
   return(ts(x, frequency = length(season), start = start))
 }


### PR DESCRIPTION
Feel free to close this if you prefer the `is.element()` pattern, since only a minor performance difference:

``` r
x <- 1:100
bench::mark(
  is.element("m", letters),
  "m" %in% letters,
  is.element(20, x),
  20 %in% x,
  check = FALSE
)
#> # A tibble: 4 × 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 "is.element(\"m\", letters)"   6.03µs   6.68µs   137723.    2.17KB     55.1
#> 2 "\"m\" %in% letters"         245.99ns 327.94ns  2699940.      256B      0  
#> 3 "is.element(20, x)"            2.71µs   3.08µs   288992.    1.27KB     57.8
#> 4 "20 %in% x"                  327.94ns 451.11ns  1624810.    1.27KB      0
```

<sup>Created on 2025-09-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>