### PR TITLE
feat: add parallelization for nnetar

### DIFF
--- a/R/newarima2.R
+++ b/R/newarima2.R
@@ -61,14 +61,14 @@
 #' See [nsdiffs()] for details.
 #' @param allowdrift If `TRUE`, models with drift terms are considered.
 #' @param allowmean If `TRUE`, models with a non-zero mean are considered.
-#' @param parallel If `TRUE` and `stepwise = FALSE`, then the
-#' specification search is done in parallel via `parallel::mclapply`. This
-#' can give a significant speedup on multicore machines. On Windows, this
-#' option always fails because forking is not supported.
+#' @param parallel If `TRUE` and `stepwise = FALSE`, then the specification
+#' search is done in parallel via [parallel::mclapply()]. This can give a
+#' significant speedup on multicore machines. On Windows, this option always
+#' fails because forking is not supported.
 #' @param num.cores Allows the user to specify the amount of parallel processes
-#' to be used if `parallel = TRUE` and `stepwise = FALSE`. If
-#' `NULL`, then the number of logical cores is automatically detected and
-#' all available cores are used.
+#' to be used if `parallel = TRUE` and `stepwise = FALSE`. If `NULL`, then the
+#' number of logical cores is automatically detected and all available cores
+#' are used.
 #'
 #' @return Same as for [Arima()]
 #' @author Rob J Hyndman

--- a/man/auto.arima.Rd
+++ b/man/auto.arima.Rd
@@ -137,15 +137,15 @@ values, a regular back transformation will result in median forecasts. If
 biasadj is \code{TRUE}, an adjustment will be made to produce mean forecasts
 and fitted values.}
 
-\item{parallel}{If \code{TRUE} and \code{stepwise = FALSE}, then the
-specification search is done in parallel via \code{parallel::mclapply}. This
-can give a significant speedup on multicore machines. On Windows, this
-option always fails because forking is not supported.}
+\item{parallel}{If \code{TRUE} and \code{stepwise = FALSE}, then the specification
+search is done in parallel via \code{\link[parallel:mclapply]{parallel::mclapply()}}. This can give a
+significant speedup on multicore machines. On Windows, this option always
+fails because forking is not supported.}
 
 \item{num.cores}{Allows the user to specify the amount of parallel processes
-to be used if \code{parallel = TRUE} and \code{stepwise = FALSE}. If
-\code{NULL}, then the number of logical cores is automatically detected and
-all available cores are used.}
+to be used if \code{parallel = TRUE} and \code{stepwise = FALSE}. If \code{NULL}, then the
+number of logical cores is automatically detected and all available cores
+are used.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 

--- a/man/nnetar.Rd
+++ b/man/nnetar.Rd
@@ -17,6 +17,8 @@ nnetar(
   model = NULL,
   subset = NULL,
   scale.inputs = TRUE,
+  parallel = FALSE,
+  num.cores = 2,
   x = y,
   ...
 )
@@ -59,6 +61,14 @@ length as \code{y}. All observations are used by default.}
 \item{scale.inputs}{If \code{TRUE}, inputs are scaled by subtracting the column
 means and dividing by their respective standard deviations. If \code{lambda}
 is not \code{NULL}, scaling is applied after Box-Cox transformation.}
+
+\item{parallel}{If \code{TRUE}, then the specification search is done in parallel
+via \code{\link[parallel:clusterApply]{parallel::parLapply()}}. This can give a significant speedup on
+multicore machines.}
+
+\item{num.cores}{Allows the user to specify the amount of parallel processes
+to be used if \code{parallel = TRUE}. If \code{NULL}, then the number of logical cores
+is automatically detected and all available cores are used.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 


### PR DESCRIPTION
closes: https://github.com/robjhyndman/forecast/issues/346

@robjhyndman this implements parallelization in the same manner as the Arima implementation i.e. via forking with `parallel::mclapply()`, hence doesn't support Windows. If you prefer, I can change it to sockets via `parallel::parLapply()` to support Windows.

There were two different argument names in the package to enable parallelization: `parallel` and `use.parallel`. Personally, I prefer `parallel` and it seems to be used more hence I stuck with it.