### PR TITLE
perf: preallocate the size of the list

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -2300,8 +2300,8 @@ autolayer.mts <- function(object, colour = TRUE, series = NULL, ...) {
     }
     series <- colnames(object)
   }
-  out <- list()
-  for (i in seq_len(NCOL(object))) {
+  out <- vector("list", NCOL(object))
+  for (i in seq_along(out)) {
     cl$series <- series[i]
     out[[i]] <- eval(cl)
   }
@@ -2409,8 +2409,8 @@ autolayer.mforecast <- function(object, series = NULL, PI = TRUE, ...) {
       series <- names(object$forecast)
     }
   }
-  out <- list()
-  for (i in seq_along(object$forecast)) {
+  out <- vector("list", length(object$forecast))
+  for (i in seq_along(out)) {
     cl$series <- series[i]
     out[[i]] <- eval(cl)
   }

--- a/R/lm.R
+++ b/R/lm.R
@@ -462,9 +462,9 @@ forecast.lm <- function(
   predict_object <- object
   predict_object$residuals <- na.omit(as.numeric(object$residuals))
 
-  out <- list()
   nl <- length(level)
-  for (i in 1:nl) {
+  out <- vector("list", nl)
+  for (i in seq_len(nl)) {
     out[[i]] <- predict(
       predict_object,
       newdata = newdata,

--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -378,8 +378,8 @@ nnetar <- function(
 
 # Aggregate several neural network models
 avnnet <- function(x, y, repeats, linout = TRUE, trace = FALSE, ...) {
-  mods <- list()
-  for (i in 1:repeats) {
+  mods <- vector("list", repeats)
+  for (i in seq_len(repeats)) {
     mods[[i]] <- nnet::nnet(x, y, linout = linout, trace = trace, ...)
   }
   structure(mods, class = "nnetarmodels")
@@ -393,8 +393,8 @@ oldmodel_avnnet <- function(x, y, size, model) {
   args <- c(args, model$nnetargs)
   # set iterations to zero (i.e. weights stay fixed)
   args$maxit <- 0
-  mods <- list()
-  for (i in 1:repeats) {
+  mods <- vector("list", repeats)
+  for (i in seq_len(repeats)) {
     args$Wts <- model$model[[i]]$wts
     mods[[i]] <- do.call(nnet::nnet, args)
   }

--- a/R/tscv.R
+++ b/R/tscv.R
@@ -214,15 +214,15 @@ CVar <- function(
   # Set up folds
   ind <- seq_len(nx)
   fold <- if (blocked) {
-    sort(rep(1:k, length.out = nx))
+    sort(rep_len(1:k, nx))
   } else {
-    sample(rep(1:k, length.out = nx))
+    sample(rep_len(1:k, nx))
   }
 
   cvacc <- matrix(NA_real_, nrow = k, ncol = 7)
-  out <- list()
-  alltestfit <- rep(NA, length.out = nx)
-  for (i in 1:k) {
+  out <- vector("list", k)
+  alltestfit <- rep_len(NA, nx)
+  for (i in seq_len(k)) {
     out[[paste0("fold", i)]] <- list()
     testset <- ind[fold == i]
     trainset <- ind[fold != i]

--- a/tests/testthat/test-modelAR.R
+++ b/tests/testthat/test-modelAR.R
@@ -9,8 +9,8 @@ test_that("Tests for modelAR", {
     trace = FALSE,
     ...
   ) {
-    mods <- list()
-    for (i in 1:repeats) {
+    mods <- vector("list", repeats)
+    for (i in seq_len(repeats)) {
       mods[[i]] <- nnet::nnet(x, y, linout = linout, trace = trace, ...)
     }
     return(structure(mods, class = "nnetarmodels"))


### PR DESCRIPTION
* use faster `rep_len()`
* preallocate the list before a loop