### PR TITLE
refactor(nnetar): use `NULL` instead of missing for size default

### DIFF
--- a/R/nnetar.R
+++ b/R/nnetar.R
@@ -99,7 +99,7 @@ nnetar <- function(
   y,
   p,
   P = 1,
-  size,
+  size = NULL,
   repeats = 20,
   xreg = NULL,
   lambda = NULL,
@@ -314,7 +314,7 @@ nnetar <- function(
   }
   # Add xreg into lagged matrix
   lags.X <- cbind(lags.X, xxreg[-(1:maxlag), , drop = FALSE])
-  if (missing(size)) {
+  if (is.null(size)) {
     size <- round((NCOL(lags.X) + 1) / 2)
   }
   # Remove missing values if present

--- a/man/nnetar.Rd
+++ b/man/nnetar.Rd
@@ -10,7 +10,7 @@ nnetar(
   y,
   p,
   P = 1,
-  size,
+  size = NULL,
   repeats = 20,
   xreg = NULL,
   lambda = NULL,


### PR DESCRIPTION
Might make sense to replace the size default from missing to `NULL` to match more of the other defaults, since size is not required here.