### PR TITLE
fix: handle newdata to make scoping work

### DIFF
--- a/R/mforecast.R
+++ b/R/mforecast.R
@@ -103,12 +103,18 @@ forecast.mlm <- function(
     model = object,
     forecast = vector("list", NCOL(object$coefficients))
   )
-
-  cl <- match.call()
-  cl[[1]] <- quote(forecast.lm)
-  cl$object <- quote(mlmsplit(object, index = i))
   for (i in seq_along(out$forecast)) {
-    out$forecast[[i]] <- eval(cl)
+    out$forecast[[i]] <- forecast.lm(
+      object = mlmsplit(object, index = i),
+      newdata = newdata,
+      h = h,
+      level = level,
+      fan = fan,
+      lambda = lambda,
+      biasadj = biasadj,
+      ts = ts,
+      ...
+    )
     out$forecast[[i]]$series <- colnames(object$coefficients)[i]
   }
   out$method <- rep("Multiple linear regression model", length(out$forecast))
@@ -178,11 +184,19 @@ forecast.mts <- function(
   ...
 ) {
   out <- list(forecast = vector("list", NCOL(object)))
-  cl <- match.call()
-  cl[[1]] <- quote(forecast.ts)
-  cl$object <- quote(object[, i])
   for (i in seq_len(NCOL(object))) {
-    out$forecast[[i]] <- eval(cl)
+    out$forecast[[i]] <- forecast.ts(
+      object = object[, i],
+      h = h,
+      level = level,
+      fan = fan,
+      robust = robust,
+      lambda = lambda,
+      biasadj = biasadj,
+      find.frequency = find.frequency,
+      allow.multiplicative.trend = allow.multiplicative.trend,
+      ...
+    )
     out$forecast[[i]]$series <- colnames(object)[i]
   }
   out$method <- vapply(out$forecast, function(x) x$method, character(1))


### PR DESCRIPTION
closes: https://github.com/robjhyndman/forecast/issues/880

The NSE doesn't seem required in this context and the simpler function invocation fixes the issue as well (see below). Also seems to be one of the few places where the `quote()` + `eval()` pattern was used.

``` r
resp <- matrix(rnorm(200), 100, 2)
colnames(resp) <- paste0("R", 1:2)

expl <- matrix(rnorm(400), 100, 4)
colnames(expl) <- paste0("E", 1:4)

fit <- stats::lm(resp ~ ., data = as.data.frame(expl))
print(fit)
#> 
#> Call:
#> stats::lm(formula = resp ~ ., data = as.data.frame(expl))
#> 
#> Coefficients:
#>              R1         R2       
#> (Intercept)  -0.052274  -0.168201
#> E1           -0.109949  -0.015305
#> E2            0.030844  -0.015019
#> E3            0.063228  -0.020700
#> E4            0.028457  -0.005038
print(class(fit))
#> [1] "mlm" "lm"

newdat <- matrix(seq(8), 2, 4)
colnames(newdat) <- paste0("E", 1:4)
print(newdat)
#>      E1 E2 E3 E4
#> [1,]  1  3  5  7
#> [2,]  2  4  6  8

forecast::forecast(
  object = fit,
  newdata = as.data.frame(newdat),
  level = 0.95
)
#> Registered S3 method overwritten by 'quantmod':
#>   method            from
#>   as.zoo.data.frame zoo
#> R1
#>   Point Forecast     Lo 95    Hi 95
#> 1      0.4456460 -1.955163 2.846455
#> 2      0.4582256 -2.139412 3.055863
#> 
#> R2
#>   Point Forecast     Lo 95    Hi 95
#> 1     -0.3673237 -2.952012 2.217364
#> 2     -0.4233844 -3.219975 2.373207

my_function <- function(my_fit, my_newdat) {
  results <- forecast::forecast(
    object = my_fit,
    newdata = as.data.frame(my_newdat),
    level = 0.95
  )
  results
}

my_function(fit, newdat)
#> R1
#>   Point Forecast     Lo 95    Hi 95
#> 1      0.4456460 -1.955163 2.846455
#> 2      0.4582256 -2.139412 3.055863
#> 
#> R2
#>   Point Forecast     Lo 95    Hi 95
#> 1     -0.3673237 -2.952012 2.217364
#> 2     -0.4233844 -3.219975 2.373207
```

<sup>Created on 2026-01-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>