### PR TITLE
fix(WhichModels): correct row and column ordering

### DIFF
--- a/R/whichmodels.R
+++ b/R/whichmodels.R
@@ -1,8 +1,8 @@
 WhichModels <- function(max.p, max.q, max.P, max.Q, maxK) {
-  grid <- expand.grid(0:max.p, 0:max.q, 0:max.P, 0:max.Q, 0:maxK, stringsAsFactors = FALSE)
+  grid <- expand.grid(0:maxK, 0:max.Q, 0:max.P, 0:max.q, 0:max.p, stringsAsFactors = FALSE)
   do.call(paste, c(rev(grid), sep = "f"))
 }
 
 UndoWhichModels <- function(n) {
-  as.numeric(unlist(strsplit(n, split = "f", fixed = TRUE)))
+  as.numeric(unlist(strsplit(n, split = "f", fixed = TRUE), use.names = FALSE))
 }

--- a/tests/testthat/test-whichmodels.R
+++ b/tests/testthat/test-whichmodels.R
@@ -1,0 +1,28 @@
+test_that("WhichModels produces correct model strings", {
+  expect_identical(WhichModels(0, 0, 0, 0, 0), "0f0f0f0f0")
+  expect_length(WhichModels(2, 1, 1, 1, 1), 3 * 2 * 2 * 2 * 2)
+  expect_identical(
+    WhichModels(1, 1, 0, 0, 0),
+    c("0f0f0f0f0", "0f1f0f0f0", "1f0f0f0f0", "1f1f0f0f0")
+  )
+})
+
+test_that("WhichModels matches original loop order", {
+  actual <- WhichModels(2, 1, 3, 1, 4)
+  expected <- character()
+  for (x1 in 0:2) {
+    for (x2 in 0:1) {
+      for (x3 in 0:3) {
+        for (x4 in 0:1) {
+          for (K in 0:4) {
+            expected <- c(
+              expected,
+              paste0(x1, "f", x2, "f", x3, "f", x4, "f", K)
+            )
+          }
+        }
+      }
+    }
+  }
+  expect_identical(actual, expected)
+})


### PR DESCRIPTION
Fix the issue from the previous change to `expand.grid()`. Now matches the identical row and column order of the original. Added couple sanity checks and small benchmark below:

``` r
which_models_new <- function(max.p, max.q, max.P, max.Q, maxK) {
  grid <- expand.grid(0:maxK, 0:max.Q, 0:max.P, 0:max.q, 0:max.p, stringsAsFactors = FALSE)
  do.call(paste, c(rev(grid), sep = "f"))
}

which_models_old <- function(max.p, max.q, max.P, max.Q, maxK) {
  total.models <- (max.p + 1) *
    (max.q + 1) *
    (max.P + 1) *
    (max.Q + 1) *
    length(0:maxK)
  x <- numeric(total.models)
  i <- 1

  for (x1 in 0:max.p) {
    for (x2 in 0:max.q) {
      for (x3 in 0:max.P) {
        for (x4 in 0:max.Q) {
          for (K in 0:maxK) {
            x[i] <- paste0(x1, "f", x2, "f", x3, "f", x4, "f", K)
            i <- i + 1
          }
        }
      }
    }
  }
  x
}

bench::mark(
  new = which_models_new(2, 5, 5, 3, 10),
  old = which_models_old(2, 5, 5, 3, 10)
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          1.23ms   1.31ms     755.    649.3KB     6.15
#> 2 old         16.72ms  16.93ms      58.7     4.5MB    67.7
```

<sup>Created on 2026-02-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>