### PR TITLE
refactor: remove unneeded installation check for ggplot2

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -96,13 +96,6 @@ ggtsbreaks <- function(x) {
 #'
 #' @export
 autoplot.acf <- function(object, ci = 0.95, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!inherits(object, "acf")) {
     stop("autoplot.acf requires a acf object, use object=object")
   }
@@ -285,13 +278,6 @@ ggCcf <- function(
 #' @rdname autoplot.acf
 #' @export
 autoplot.mpacf <- function(object, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!inherits(object, "mpacf")) {
     stop("autoplot.mpacf requires a mpacf object, use object=object")
   }
@@ -416,13 +402,6 @@ ggtaperedpacf <- function(x, ...) {
 #' @rdname plot.Arima
 #' @export
 autoplot.Arima <- function(object, type = c("both", "ar", "ma"), ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (is.Arima(object)) {
     # Detect type
     type <- match.arg(type)
@@ -534,13 +513,6 @@ autoplot.decomposed.ts <- function(
   range.bars = NULL,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!inherits(object, "decomposed.ts")) {
     stop("autoplot.decomposed.ts requires a decomposed.ts object")
   }
@@ -651,13 +623,6 @@ autoplot.decomposed.ts <- function(
 #' @rdname plot.ets
 #' @export
 autoplot.ets <- function(object, range.bars = NULL, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!is.ets(object)) {
     stop("autoplot.ets requires an ets object, use object=object")
   }
@@ -822,13 +787,6 @@ autoplot.forecast <- function(
   flwd = 0.5,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!is.forecast(object)) {
     stop("autoplot.forecast requires a forecast object, use object=object")
   }
@@ -1036,13 +994,6 @@ autoplot.mforecast <- function(
   colour = FALSE,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!is.mforecast(object)) {
     stop("autoplot.mforecast requires a mforecast object, use object=object")
   }
@@ -1128,12 +1079,6 @@ ggtsdisplay <- function(
   theme = NULL,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
   if (NCOL(x) > 1) {
     stop("ggtsdisplay is only for univariate time series")
   }
@@ -1316,13 +1261,6 @@ gglagplot <- function(
   seasonal = TRUE,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   freq <- frequency(x)
   if (freq > 1) {
     linecol <- cycle(x)
@@ -1477,13 +1415,6 @@ gglagchull <- function(
   diag.col = "gray",
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   # Make sure lags is evaluated
   tmp <- lags
   x <- as.matrix(x)
@@ -1583,13 +1514,6 @@ ggsubseriesplot <- function(
   phase = cycle(x),
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!is.ts(x)) {
     stop("ggsubseriesplot requires a ts object, use x=object")
   }
@@ -1706,12 +1630,6 @@ ggseasonplot <- function(
   labelgap = 0.04,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
   if (!is.ts(x)) {
     stop("autoplot.seasonplot requires a ts object, use x=object")
   }
@@ -1873,13 +1791,6 @@ ggseasonplot <- function(
 #' @rdname plot.forecast
 #' @export
 autoplot.splineforecast <- function(object, PI = TRUE, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   p <- autoplot(object$x) + autolayer(object)
   p <- p + ggplot2::geom_point(size = 2)
   fit <- data.frame(
@@ -1903,13 +1814,6 @@ autoplot.splineforecast <- function(object, PI = TRUE, ...) {
 #' @rdname autoplot.seas
 #' @export
 autoplot.stl <- function(object, labels = NULL, range.bars = TRUE, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!inherits(object, "stl")) {
     stop("autoplot.stl requires a stl object, use x=object")
   }
@@ -2021,13 +1925,6 @@ autoplot.stl <- function(object, labels = NULL, range.bars = TRUE, ...) {
 #' @rdname autoplot.seas
 #' @export
 autoplot.StructTS <- function(object, labels = NULL, range.bars = TRUE, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!inherits(object, "StructTS")) {
     stop("autoplot.StructTS requires a StructTS object.")
   }
@@ -2138,12 +2035,6 @@ autoplot.StructTS <- function(object, labels = NULL, range.bars = TRUE, ...) {
 #'
 #' @export
 autoplot.seas <- function(object, labels = NULL, range.bars = NULL, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
   if (!inherits(object, "seas")) {
     stop("autoplot.seas requires a seas object")
   }
@@ -2259,12 +2150,6 @@ autoplot.seas <- function(object, labels = NULL, range.bars = NULL, ...) {
 #' @rdname autoplot.ts
 #' @export
 autolayer.mts <- function(object, colour = TRUE, series = NULL, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
   cl <- match.call()
   cl[[1]] <- quote(autolayer)
   cl$object <- quote(object[, i])
@@ -2302,13 +2187,6 @@ autolayer.msts <- function(object, series = NULL, ...) {
 #' @rdname autoplot.ts
 #' @export
 autolayer.ts <- function(object, colour = TRUE, series = NULL, ...) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   tsdata <- data.frame(
     timeVal = as.numeric(time(object)),
     series = if (is.null(series)) deparse1(substitute(object)) else series,
@@ -2434,13 +2312,6 @@ autoplot.ts <- function(
   main = NULL,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!is.ts(object)) {
     stop("autoplot.ts requires a ts object, use object=object")
   }
@@ -2493,13 +2364,6 @@ autoplot.mts <- function(
   main = NULL,
   ...
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (!stats::is.mts(object)) {
     stop("autoplot.mts requires a mts object, use x=object")
   }
@@ -3118,13 +2982,6 @@ gghistogram <- function(
   bins,
   boundary = 0
 ) {
-  if (!requireNamespace("ggplot2", quietly = TRUE)) {
-    stop(
-      "ggplot2 is needed for this function to work. Install it via install.packages(\"ggplot2\")",
-      call. = FALSE
-    )
-  }
-
   if (missing(bins)) {
     bins <- min(500, grDevices::nclass.FD(na.exclude(x)))
   }


### PR DESCRIPTION
ggplot2 is currently a hard dep, therefore the installation checks are redundant unless it's made to a soft dep, moved to suggests, and the exports are handled differently. In fabletools ggplot2 is currently also a hard dep. But I don't have a strong opinion on it either way.