### PR TITLE
fix(mstl): use `attr()` to access lambda on mstl matrix objects

### DIFF
--- a/R/mstl.R
+++ b/R/mstl.R
@@ -60,6 +60,7 @@ mstl <- function(
   # Transform if necessary
   if (!is.null(lambda)) {
     x <- BoxCox(x, lambda = lambda)
+    lambda <- attr(x, "lambda")
     attr(lambda, "biasadj") <- biasadj
   }
 
@@ -110,6 +111,7 @@ mstl <- function(
   colnames(output)[NCOL(output)] <- "Remainder"
 
   output <- copy_msts(origx, output)
+  attr(output, "lambda") <- lambda
   class(output) <- c("mstl", class(output))
   output
 }
@@ -340,8 +342,8 @@ forecast.mstl <- function(
   h = frequency(object) * 2,
   level = c(80, 95),
   fan = FALSE,
-  lambda = object$lambda,
-  biasadj = attr(object$lambda, "biasadj"),
+  lambda = attr(object, "lambda"),
+  biasadj = attr(attr(object, "lambda"), "biasadj"),
   xreg = NULL,
   newxreg = NULL,
   allow.multiplicative.trend = FALSE,

--- a/tests/testthat/test-mstl.R
+++ b/tests/testthat/test-mstl.R
@@ -1,0 +1,15 @@
+test_that("forecast.mstl works without lambda", {
+  fit <- mstl(AirPassengers)
+  fc <- forecast(fit, h = 12)
+  expect_s3_class(fc, "forecast")
+  expect_length(fc$mean, 12)
+  expect_null(fc$lambda)
+})
+
+test_that("forecast.mstl works with lambda", {
+  fit <- mstl(AirPassengers, lambda = 0)
+  fc <- forecast(fit, h = 12)
+  expect_s3_class(fc, "forecast")
+  expect_length(fc$mean, 12)
+  expect_equal(fc$lambda, 0, ignore_attr = TRUE)
+})


### PR DESCRIPTION
closes: https://github.com/robjhyndman/forecast/issues/1097

Wasn't caught due to missing test coverage and mstl is the only place working with matrix object hence needs different treatment of `lambda`. 369dbbd1 exposed the error, but prior lambda was already silently ignored.

Might be more prety to use `NULL` for the default values, but this would be consistent with the rest of the codebase.