### PR TITLE
feat: add alpha optimization for croston

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # forecast (development version)
 
+* `croston_model()` fitted values for periods before the first non-zero demand are now `NA` instead of `0`.
+* `croston_model()` gains an `initial` parameter to control the initialization method for the interval component.
+* `croston_model()` gains support for optimized alpha and initial value selection via `alpha = NULL`.
 * `forecast.Arima()` now correctly passes `xreg` when `bootstrap = TRUE` (#1115).
 
 # forecast 9.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * `autolayer()` now labels an unnamed `msts` series with the name of the object instead of "NULL".
 * `autoplot.forecast()` no longer errors for cross-sectional regression models fitted without an intercept.
 * `bld.mbb.bootstrap()` no longer errors when `num = 1` and now validates that `num` is a positive integer.
-* `croston_model()` and `croston()` gained an `opt_alpha` argument to optimize the smoothing parameters from the supplied `alpha` starting values and an `opt_crit` argument to select the optimization criterion, and `alpha` may now be length 2 to use separate smoothing parameters for the demand and interval components.
+* `croston_model()` and `croston()` can now optimize and separately specify Croston smoothing parameters.
 * `croston_model()` now returns `NA` for fitted values before the first non-zero demand instead of 0.
 * `forecast.Arima()` now correctly passes `xreg` when `bootstrap = TRUE` (#1115).
 * `forecast.ets()` now gives the intended error message when forecasting fails for a multiplicative trend model.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 * `autolayer()` now labels an unnamed `msts` series with the name of the object instead of "NULL".
 * `autoplot.forecast()` no longer errors for cross-sectional regression models fitted without an intercept.
 * `bld.mbb.bootstrap()` no longer errors when `num = 1` and now validates that `num` is a positive integer.
+* `croston_model()` and `croston()` gained an `opt_alpha` argument to optimize the smoothing parameters from the supplied `alpha` starting values and an `opt_crit` argument to select the optimization criterion, and `alpha` may now be length 2 to use separate smoothing parameters for the demand and interval components.
+* `croston_model()` now returns `NA` for fitted values before the first non-zero demand instead of 0.
 * `forecast.Arima()` now correctly passes `xreg` when `bootstrap = TRUE` (#1115).
 * `forecast.ets()` now gives the intended error message when forecasting fails for a multiplicative trend model.
 * `mstl()` now drops short seasonal periods from the `msts` attribute, so `forecast.stlm()` no longer errors.

--- a/R/croston.R
+++ b/R/croston.R
@@ -19,10 +19,17 @@
 #' the interval SES application.
 #'
 #' @inheritParams Arima
-#' @param alpha Value of alpha. Default value is 0.1.
+#' @param alpha Value of alpha. Default value is 0.1. If `NULL`, the alpha and initial values are
+#'   jointly optimized.
 #' @param type Which variant of Croston's method to use. Defaults to `"croston"` for
 #' Croston's method, but can also be set to `"sba"` for the Syntetos-Boylan
 #' approximation, and `"sbj"` for the Shale-Boylan-Johnston method.
+#' @param init Either a string specifying the initialization method for the SES components
+#'   (`"naive"` or `"mean"`), or a numeric vector of length 2 giving the initial values for
+#'   demand and interval respectively. When a string is used, demand is initialized to the first
+#'   non-zero value and interval is initialized using the selected method. String values are used as
+#'   starting points for optimization when `alpha = NULL`; numeric values are fixed.
+#' @param opt.crit Optimization criterion when `alpha = NULL`. Either `"mse"` or `"mae"`.
 #' @references Croston, J. (1972) "Forecasting and stock control for
 #' intermittent demands", \emph{Operational Research Quarterly}, \bold{23}(3),
 #' 289-303.
@@ -43,9 +50,16 @@
 #' fit <- croston_model(y)
 #' forecast(fit) |> autoplot()
 #' @export
-croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
+croston_model <- function(
+  y,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae")
+) {
   type <- match.arg(type)
-  if (alpha < 0 || alpha > 1) {
+  opt.crit <- match.arg(opt.crit)
+  if (!is.null(alpha) && (alpha < 0 || alpha > 1)) {
     stop("alpha must be between 0 and 1")
   }
   if (any(y < 0)) {
@@ -59,11 +73,96 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
   y <- as.ts(y)
   y_demand <- y[non_zero]
   y_interval <- c(non_zero[1], diff(non_zero))
+  if (is.numeric(init)) {
+    if (length(init) != 2) {
+      stop("init must be a numeric vector of length 2 (demand, interval)")
+    }
+    if (init[1] < 0) {
+      stop("Initial demand must be non-negative")
+    }
+    if (init[2] < 1) {
+      stop("Initial interval must be at least 1")
+    }
+    init_demand <- init[1]
+    init_interval <- init[2]
+    opt_init <- FALSE
+  } else {
+    init <- match.arg(init)
+    init_demand <- y_demand[1]
+    init_interval <- if (init == "mean") mean(y_interval) else y_interval[1]
+    opt_init <- TRUE
+  }
+  if (is.null(alpha)) {
+    par <- c(0.1, init_demand, init_interval)
+    # Only optimize init values if not user-supplied,
+    # and init_interval only if more than one feasible value
+    par_est <- c(TRUE, opt_init, opt_init && max(y_interval) > 1)
+    opt <- optim(
+      par = par[par_est],
+      fn = function(opt_par) {
+        par[par_est] <- opt_par
+        croston_cost(
+          y,
+          alpha = par[1],
+          y_demand,
+          y_interval,
+          init_demand = par[2],
+          init_interval = par[3],
+          non_zero,
+          type,
+          opt.crit
+        )
+      },
+      lower = c(0, 0, 1)[par_est],
+      upper = c(1, max(y_demand), max(y_interval))[par_est],
+      method = "L-BFGS-B",
+      control = list(maxit = 2000)
+    )
+    par[par_est] <- opt$par
+    alpha <- min(max(par[1], 0), 1)
+    init_demand <- par[2]
+    init_interval <- par[3]
+  }
+  res <- croston_fit(
+    alpha,
+    y_demand,
+    y_interval,
+    init_demand,
+    init_interval,
+    non_zero,
+    length(y),
+    type
+  )
+  output <- list(
+    alpha = alpha,
+    type = type,
+    init = init,
+    y = y,
+    fit_demand = res$fit_demand,
+    fit_interval = res$fit_interval,
+    fitted = res$fitted,
+    residuals = y - res$fitted,
+    series = series
+  )
+  output$call <- match.call()
+  structure(output, class = c("fc_model", "croston_model"))
+}
+
+croston_fit <- function(
+  alpha,
+  y_demand,
+  y_interval,
+  init_demand,
+  init_interval,
+  non_zero,
+  n,
+  type
+) {
   k <- length(y_demand)
   fit_demand <- numeric(k)
   fit_interval <- numeric(k)
-  fit_demand[1] <- y_demand[1]
-  fit_interval[1] <- y_interval[1]
+  fit_demand[1] <- init_demand
+  fit_interval[1] <- init_interval
   for (i in 2:k) {
     fit_demand[i] <- fit_demand[i - 1] +
       alpha * (y_demand[i] - fit_demand[i - 1])
@@ -78,20 +177,37 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
     coeff <- 1
   }
   ratio <- coeff * fit_demand / fit_interval
-  fits <- rep(c(0, ratio), diff(c(0, non_zero, length(y))))
-  fits[1] <- NA_real_
-  output <- list(
-    alpha = alpha,
-    type = type,
-    y = y,
-    fit_demand = fit_demand,
-    fit_interval = fit_interval,
-    fitted = fits,
-    residuals = y - fits,
-    series = series
+  fitted <- rep(c(NA_real_, ratio), diff(c(0, non_zero, n)))
+  list(fit_demand = fit_demand, fit_interval = fit_interval, fitted = fitted)
+}
+
+croston_cost <- function(
+  y,
+  alpha,
+  y_demand,
+  y_interval,
+  init_demand,
+  init_interval,
+  non_zero,
+  type,
+  opt.crit
+) {
+  res <- croston_fit(
+    alpha,
+    y_demand,
+    y_interval,
+    init_demand,
+    init_interval,
+    non_zero,
+    length(y),
+    type
   )
-  output$call <- match.call()
-  structure(output, class = c("fc_model", "croston_model"))
+  resid <- y - res$fitted
+  if (opt.crit == "mae") {
+    mean(abs(resid), na.rm = TRUE)
+  } else {
+    mean(resid^2, na.rm = TRUE)
+  }
 }
 
 #' @export
@@ -171,8 +287,22 @@ forecast.croston_model <- function(object, h = 10, ...) {
 #' @param x Deprecated. Included for backwards compatibility.
 #' @inheritParams croston_model
 #' @export
-croston <- function(y, h = 10, alpha = 0.1, type = c("croston", "sba", "sbj"), x = y) {
-  fit <- croston_model(x, alpha = alpha, type = type)
+croston <- function(
+  y,
+  h = 10,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae"),
+  x = y
+) {
+  fit <- croston_model(
+    x,
+    alpha = alpha,
+    type = type,
+    init = init,
+    opt.crit = opt.crit
+  )
   fit$series <- deparse1(substitute(y))
   forecast(fit, h = h)
 }

--- a/R/croston.R
+++ b/R/croston.R
@@ -19,10 +19,21 @@
 #' the interval SES application.
 #'
 #' @inheritParams Arima
-#' @param alpha Value of alpha. Default value is 0.1.
-#' @param type Which variant of Croston's method to use. Defaults to `"croston"` for
-#' Croston's method, but can also be set to `"sba"` for the Syntetos-Boylan
-#' approximation, and `"sbj"` for the Shale-Boylan-Johnston method.
+#' @param alpha Value of alpha. Default value is 0.1. If `NULL`, the alpha and
+#'   initial values are jointly optimized.
+#' @param type Which variant of Croston's method to use. Defaults to
+#'   `"croston"` for Croston's method, but can also be set to `"sba"` for the
+#'   Syntetos-Boylan approximation, and `"sbj"` for the Shale-Boylan-Johnston
+#'   method.
+#' @param init Either a string specifying the initialization method for the
+#'   SES components (`"naive"` or `"mean"`), or a numeric vector of length 2
+#'   giving the initial values for demand and interval respectively. When a
+#'   string is used, demand is initialized to the first non-zero value and
+#'   interval is initialized using the selected method. String values are used
+#'   as starting points for optimization when `alpha = NULL`; numeric values
+#'   are fixed.
+#' @param opt.crit Optimization criterion when `alpha = NULL`. Either `"mse"`
+#'   or `"mae"`.
 #' @references Croston, J. (1972) "Forecasting and stock control for
 #' intermittent demands", \emph{Operational Research Quarterly}, \bold{23}(3),
 #' 289-303.
@@ -43,9 +54,16 @@
 #' fit <- croston_model(y)
 #' forecast(fit) |> autoplot()
 #' @export
-croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
+croston_model <- function(
+  y,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae")
+) {
   type <- match.arg(type)
-  if (alpha < 0 || alpha > 1) {
+  opt.crit <- match.arg(opt.crit)
+  if (!is.null(alpha) && (alpha < 0 || alpha > 1)) {
     stop("alpha must be between 0 and 1")
   }
   if (any(y < 0)) {
@@ -59,11 +77,100 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
   y <- as.ts(y)
   y_demand <- y[non_zero]
   y_interval <- c(non_zero[1], diff(non_zero))
+  if (is.numeric(init)) {
+    if (length(init) != 2) {
+      stop("init must be a numeric vector of length 2 (demand, interval)")
+    }
+    if (init[1] < 0) {
+      stop("Initial demand must be non-negative")
+    }
+    if (init[2] < 1) {
+      stop("Initial interval must be at least 1")
+    }
+    init_demand <- init[1]
+    init_interval <- init[2]
+    opt_init <- FALSE
+  } else {
+    init <- match.arg(init)
+    init_demand <- y_demand[1]
+    init_interval <- if (init == "mean") mean(y_interval) else y_interval[1]
+    opt_init <- TRUE
+  }
+  if (is.null(alpha)) {
+    n <- length(y)
+    par <- c(0.1, init_demand, init_interval)
+    # Only optimize init values if not user-supplied,
+    # and init_interval only if more than one feasible value
+    par_est <- c(TRUE, opt_init, opt_init && max(y_interval) > 1)
+    opt <- optim(
+      par = par[par_est],
+      fn = function(opt_par) {
+        pars <- par
+        pars[par_est] <- opt_par
+        croston_cost(
+          y = y,
+          alpha = pars[1],
+          y_demand = y_demand,
+          y_interval = y_interval,
+          init_demand = pars[2],
+          init_interval = pars[3],
+          non_zero = non_zero,
+          n = n,
+          type = type,
+          opt.crit = opt.crit
+        )
+      },
+      lower = c(0, 0, 1)[par_est],
+      upper = c(1, max(y_demand), max(y_interval))[par_est],
+      method = "L-BFGS-B",
+      control = list(maxit = 2000)
+    )
+    par[par_est] <- opt$par
+    alpha <- min(max(par[1], 0), 1)
+    init_demand <- par[2]
+    init_interval <- par[3]
+  }
+  res <- croston_estimate(
+    alpha,
+    y_demand,
+    y_interval,
+    init_demand,
+    init_interval,
+    non_zero,
+    length(y),
+    type
+  )
+  output <- list(
+    alpha = alpha,
+    type = type,
+    init = init,
+    y = y,
+    fit_demand = res$fit_demand,
+    fit_interval = res$fit_interval,
+    ratio = res$ratio,
+    fitted = res$fitted,
+    residuals = y - res$fitted,
+    series = series
+  )
+  output$call <- match.call()
+  structure(output, class = c("fc_model", "croston_model"))
+}
+
+croston_estimate <- function(
+  alpha,
+  y_demand,
+  y_interval,
+  init_demand,
+  init_interval,
+  non_zero,
+  n,
+  type
+) {
   k <- length(y_demand)
   fit_demand <- numeric(k)
   fit_interval <- numeric(k)
-  fit_demand[1] <- y_demand[1]
-  fit_interval[1] <- y_interval[1]
+  fit_demand[1] <- init_demand
+  fit_interval[1] <- init_interval
   for (i in 2:k) {
     fit_demand[i] <- fit_demand[i - 1] +
       alpha * (y_demand[i] - fit_demand[i - 1])
@@ -78,21 +185,43 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
     coeff <- 1
   }
   ratio <- coeff * fit_demand / fit_interval
-  fits <- rep(c(0, ratio), diff(c(0, non_zero, length(y))))
-  fits[1] <- NA_real_
-  output <- list(
-    alpha = alpha,
-    type = type,
-    y = y,
+  fitted <- rep(c(NA_real_, ratio), diff(c(0, non_zero, n)))
+  list(
     fit_demand = fit_demand,
     fit_interval = fit_interval,
     ratio = ratio[k],
-    fitted = fits,
-    residuals = y - fits,
-    series = series
+    fitted = fitted
   )
-  output$call <- match.call()
-  structure(output, class = c("fc_model", "croston_model"))
+}
+
+croston_cost <- function(
+  y,
+  alpha,
+  y_demand,
+  y_interval,
+  init_demand,
+  init_interval,
+  non_zero,
+  n,
+  type,
+  opt.crit
+) {
+  res <- croston_estimate(
+    alpha,
+    y_demand,
+    y_interval,
+    init_demand,
+    init_interval,
+    non_zero,
+    n,
+    type
+  )
+  resid <- y - res$fitted
+  if (opt.crit == "mae") {
+    mean(abs(resid), na.rm = TRUE)
+  } else {
+    mean(resid^2, na.rm = TRUE)
+  }
 }
 
 #' @export
@@ -172,8 +301,22 @@ forecast.croston_model <- function(object, h = 10, ...) {
 #' @param x Deprecated. Included for backwards compatibility.
 #' @inheritParams croston_model
 #' @export
-croston <- function(y, h = 10, alpha = 0.1, type = c("croston", "sba", "sbj"), x = y) {
-  fit <- croston_model(x, alpha = alpha, type = type)
+croston <- function(
+  y,
+  h = 10,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae"),
+  x = y
+) {
+  fit <- croston_model(
+    x,
+    alpha = alpha,
+    type = type,
+    init = init,
+    opt.crit = opt.crit
+  )
   fit$series <- deparse1(substitute(y))
   forecast(fit, h = h)
 }

--- a/R/croston.R
+++ b/R/croston.R
@@ -348,10 +348,10 @@ croston <- function(
   h = 10,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
+  x = y,
   opt_alpha = FALSE,
   opt_crit = c("mse", "mae"),
-  init = c("naive", "mean"),
-  x = y
+  init = c("naive", "mean")
 ) {
   fit <- croston_model(
     x,

--- a/R/croston.R
+++ b/R/croston.R
@@ -144,6 +144,8 @@ croston_model <- function(
     alpha = alpha,
     type = type,
     init = init,
+    init_demand = init_demand,
+    init_interval = init_interval,
     y = y,
     fit_demand = res$fit_demand,
     fit_interval = res$fit_interval,
@@ -233,6 +235,14 @@ print.croston_model <- function(
   cat("Call:", deparse(x$call), "\n\n")
   cat("alpha:", format(x$alpha, digits = digits), "\n")
   cat("method:", x$type, "\n")
+  cat(
+    "initial:",
+    "demand =",
+    format(x$init_demand, digits = digits),
+    ", interval =",
+    format(x$init_interval, digits = digits),
+    "\n"
+  )
   invisible(x)
 }
 

--- a/R/croston.R
+++ b/R/croston.R
@@ -19,29 +19,23 @@
 #' the interval SES application.
 #'
 #' @inheritParams Arima
-#' @param alpha Smoothing parameter. A single value (the default, `0.1`) uses
-#'   the same smoothing parameter for both the demand and interval SES
-#'   applications. A numeric vector of length 2 uses separate parameters, with
-#'   `alpha[1]` for the demand and `alpha[2]` for the interval. Each value must
-#'   be between 0 and 1.
-#' @param type Which variant of Croston's method to use. Defaults to
-#'   `"croston"` for Croston's method, but can also be set to `"sba"` for the
-#'   Syntetos-Boylan approximation, and `"sbj"` for the Shale-Boylan-Johnston
-#'   method.
-#' @param opt_alpha If `TRUE`, the smoothing parameter(s) are optimized, using
-#'   the supplied `alpha` value(s) as starting points. A single `alpha`
-#'   optimizes one shared parameter, while a length-2 `alpha` optimizes the
-#'   demand and interval parameters separately. Defaults to `FALSE`, which uses
-#'   the supplied `alpha` value(s) directly.
-#' @param opt_crit Optimization criterion used when `opt_alpha = TRUE`. Either
-#'   `"mse"` (mean squared error) or `"mae"` (mean absolute error).
-#' @param init Initial values for the demand and interval SES applications.
-#'   Either a string giving the initialization method (`"naive"`, the default,
-#'   initializes the interval to the first interval; `"mean"` to the mean of
-#'   the intervals; both initialize the demand to the first non-zero value), or
-#'   a numeric vector of length 2 giving the initial demand and interval
-#'   directly. When `opt_alpha = TRUE`, string-derived initial values are
-#'   optimized jointly with `alpha`, while numeric values are held fixed.
+#' @param alpha Smoothing parameter(s), each between 0 and 1. A single value
+#' (the default, `0.1`) is shared by the demand and interval SES applications. A
+#' length-2 vector uses `alpha[1]` for the demand and `alpha[2]` for the
+#' interval.
+#' @param type Which variant of Croston's method to use. Defaults to `"croston"`
+#' for Croston's method, but can also be set to `"sba"` for the Syntetos-Boylan
+#' approximation, and `"sbj"` for the Shale-Boylan-Johnston method.
+#' @param opt_alpha If `TRUE`, optimize the smoothing parameter(s) starting from
+#' `alpha`. Defaults to `FALSE`, which uses `alpha` directly.
+#' @param opt_crit Optimization criterion when `opt_alpha = TRUE`. One of `"mse"`
+#' (mean squared error) or `"mae"` (mean absolute error).
+#' @param init Initial demand and interval values. Either a string method or a
+#' length-2 numeric `c(demand, interval)`. The `"naive"` method (the default)
+#' takes the interval from the first interval and `"mean"` from the mean
+#' interval, both taking demand from the first non-zero value. String values are
+#' optimized alongside `alpha` when `opt_alpha = TRUE`, while numeric values are
+#' held fixed.
 #' @references Croston, J. (1972) "Forecasting and stock control for
 #' intermittent demands", \emph{Operational Research Quarterly}, \bold{23}(3),
 #' 289-303.

--- a/R/croston.R
+++ b/R/croston.R
@@ -19,21 +19,22 @@
 #' the interval SES application.
 #'
 #' @inheritParams Arima
-#' @param alpha Value of alpha. Default value is 0.1. If `NULL`, the alpha and
-#'   initial values are jointly optimized.
+#' @param alpha Smoothing parameter. A single value (the default, `0.1`) uses
+#'   the same smoothing parameter for both the demand and interval SES
+#'   applications. A numeric vector of length 2 uses separate parameters, with
+#'   `alpha[1]` for the demand and `alpha[2]` for the interval. Each value must
+#'   be between 0 and 1.
 #' @param type Which variant of Croston's method to use. Defaults to
 #'   `"croston"` for Croston's method, but can also be set to `"sba"` for the
 #'   Syntetos-Boylan approximation, and `"sbj"` for the Shale-Boylan-Johnston
 #'   method.
-#' @param init Either a string specifying the initialization method for the
-#'   SES components (`"naive"` or `"mean"`), or a numeric vector of length 2
-#'   giving the initial values for demand and interval respectively. When a
-#'   string is used, demand is initialized to the first non-zero value and
-#'   interval is initialized using the selected method. String values are used
-#'   as starting points for optimization when `alpha = NULL`; numeric values
-#'   are fixed.
-#' @param opt.crit Optimization criterion when `alpha = NULL`. Either `"mse"`
-#'   or `"mae"`.
+#' @param opt_alpha If `TRUE`, the smoothing parameter(s) are optimized, using
+#'   the supplied `alpha` value(s) as starting points. A single `alpha`
+#'   optimizes one shared parameter, while a length-2 `alpha` optimizes the
+#'   demand and interval parameters separately. Defaults to `FALSE`, which uses
+#'   the supplied `alpha` value(s) directly.
+#' @param opt_crit Optimization criterion used when `opt_alpha = TRUE`. Either
+#'   `"mse"` (mean squared error) or `"mae"` (mean absolute error).
 #' @references Croston, J. (1972) "Forecasting and stock control for
 #' intermittent demands", \emph{Operational Research Quarterly}, \bold{23}(3),
 #' 289-303.
@@ -58,12 +59,15 @@ croston_model <- function(
   y,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
-  init = c("naive", "mean"),
-  opt.crit = c("mse", "mae")
+  opt_alpha = FALSE,
+  opt_crit = c("mse", "mae")
 ) {
   type <- match.arg(type)
-  opt.crit <- match.arg(opt.crit)
-  if (!is.null(alpha) && (alpha < 0 || alpha > 1)) {
+  opt_crit <- match.arg(opt_crit)
+  if (!is.numeric(alpha) || length(alpha) < 1 || length(alpha) > 2) {
+    stop("alpha must be a numeric vector of length 1 or 2")
+  }
+  if (any(alpha < 0 | alpha > 1)) {
     stop("alpha must be between 0 and 1")
   }
   if (any(y < 0)) {
@@ -77,75 +81,48 @@ croston_model <- function(
   y <- as.ts(y)
   y_demand <- y[non_zero]
   y_interval <- c(non_zero[1], diff(non_zero))
-  if (is.numeric(init)) {
-    if (length(init) != 2) {
-      stop("init must be a numeric vector of length 2 (demand, interval)")
-    }
-    if (init[1] < 0) {
-      stop("Initial demand must be non-negative")
-    }
-    if (init[2] < 1) {
-      stop("Initial interval must be at least 1")
-    }
-    init_demand <- init[1]
-    init_interval <- init[2]
-    opt_init <- FALSE
-  } else {
-    init <- match.arg(init)
-    init_demand <- y_demand[1]
-    init_interval <- if (init == "mean") mean(y_interval) else y_interval[1]
-    opt_init <- TRUE
-  }
-  if (is.null(alpha)) {
-    n <- length(y)
-    par <- c(0.1, init_demand, init_interval)
-    # Only optimize init values if not user-supplied,
-    # and init_interval only if more than one feasible value
-    par_est <- c(TRUE, opt_init, opt_init && max(y_interval) > 1)
+  n <- length(y)
+  alpha_demand <- alpha[1]
+  alpha_interval <- alpha[length(alpha)]
+  if (opt_alpha) {
+    separate <- length(alpha) == 2
+    par <- if (separate) c(alpha_demand, alpha_interval) else alpha_demand
     opt <- optim(
-      par = par[par_est],
-      fn = function(opt_par) {
-        pars <- par
-        pars[par_est] <- opt_par
+      par = par,
+      fn = function(par) {
         croston_cost(
+          alpha_demand = par[1],
+          alpha_interval = par[length(par)],
           y = y,
-          alpha = pars[1],
           y_demand = y_demand,
           y_interval = y_interval,
-          init_demand = pars[2],
-          init_interval = pars[3],
           non_zero = non_zero,
           n = n,
           type = type,
-          opt.crit = opt.crit
+          opt_crit = opt_crit
         )
       },
-      lower = c(0, 0, 1)[par_est],
-      upper = c(1, max(y_demand), max(y_interval))[par_est],
+      lower = 0,
+      upper = 1,
       method = "L-BFGS-B",
       control = list(maxit = 2000)
     )
-    par[par_est] <- opt$par
-    alpha <- min(max(par[1], 0), 1)
-    init_demand <- par[2]
-    init_interval <- par[3]
+    alpha <- opt$par
+    alpha_demand <- alpha[1]
+    alpha_interval <- alpha[length(alpha)]
   }
   res <- croston_estimate(
-    alpha,
+    alpha_demand,
+    alpha_interval,
     y_demand,
     y_interval,
-    init_demand,
-    init_interval,
     non_zero,
-    length(y),
+    n,
     type
   )
   output <- list(
     alpha = alpha,
     type = type,
-    init = init,
-    init_demand = init_demand,
-    init_interval = init_interval,
     y = y,
     fit_demand = res$fit_demand,
     fit_interval = res$fit_interval,
@@ -159,11 +136,10 @@ croston_model <- function(
 }
 
 croston_estimate <- function(
-  alpha,
+  alpha_demand,
+  alpha_interval,
   y_demand,
   y_interval,
-  init_demand,
-  init_interval,
   non_zero,
   n,
   type
@@ -171,18 +147,18 @@ croston_estimate <- function(
   k <- length(y_demand)
   fit_demand <- numeric(k)
   fit_interval <- numeric(k)
-  fit_demand[1] <- init_demand
-  fit_interval[1] <- init_interval
+  fit_demand[1] <- y_demand[1]
+  fit_interval[1] <- y_interval[1]
   for (i in 2:k) {
     fit_demand[i] <- fit_demand[i - 1] +
-      alpha * (y_demand[i] - fit_demand[i - 1])
+      alpha_demand * (y_demand[i] - fit_demand[i - 1])
     fit_interval[i] <- fit_interval[i - 1] +
-      alpha * (y_interval[i] - fit_interval[i - 1])
+      alpha_interval * (y_interval[i] - fit_interval[i - 1])
   }
   if (type == "sba") {
-    coeff <- 1 - alpha / 2
+    coeff <- 1 - alpha_interval / 2
   } else if (type == "sbj") {
-    coeff <- 1 - alpha / (2 - alpha)
+    coeff <- 1 - alpha_interval / (2 - alpha_interval)
   } else {
     coeff <- 1
   }
@@ -197,29 +173,27 @@ croston_estimate <- function(
 }
 
 croston_cost <- function(
+  alpha_demand,
+  alpha_interval,
   y,
-  alpha,
   y_demand,
   y_interval,
-  init_demand,
-  init_interval,
   non_zero,
   n,
   type,
-  opt.crit
+  opt_crit
 ) {
   res <- croston_estimate(
-    alpha,
+    alpha_demand,
+    alpha_interval,
     y_demand,
     y_interval,
-    init_demand,
-    init_interval,
     non_zero,
     n,
     type
   )
   resid <- y - res$fitted
-  if (opt.crit == "mae") {
+  if (opt_crit == "mae") {
     mean(abs(resid), na.rm = TRUE)
   } else {
     mean(resid^2, na.rm = TRUE)
@@ -233,16 +207,18 @@ print.croston_model <- function(
   ...
 ) {
   cat("Call:", deparse(x$call), "\n\n")
-  cat("alpha:", format(x$alpha, digits = digits), "\n")
+  if (length(x$alpha) == 2) {
+    cat(
+      "alpha: demand =",
+      format(x$alpha[1], digits = digits),
+      ", interval =",
+      format(x$alpha[2], digits = digits),
+      "\n"
+    )
+  } else {
+    cat("alpha:", format(x$alpha, digits = digits), "\n")
+  }
   cat("method:", x$type, "\n")
-  cat(
-    "initial:",
-    "demand =",
-    format(x$init_demand, digits = digits),
-    ", interval =",
-    format(x$init_interval, digits = digits),
-    "\n"
-  )
   invisible(x)
 }
 
@@ -256,7 +232,8 @@ print.croston_model <- function(
 #' simple exponential smoothing (SES) on the non-zero elements of the time
 #' series and a separate application of SES to the times between non-zero
 #' elements of the time series. The smoothing parameters of the two
-#' applications of SES are assumed to be equal and are denoted by `alpha`.
+#' applications of SES are denoted by `alpha`, and may be shared (the default)
+#' or specified separately for the demand and interval components.
 #'
 #' Note that prediction intervals are not computed as Croston's method has no
 #' underlying stochastic model.
@@ -316,16 +293,16 @@ croston <- function(
   h = 10,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
-  init = c("naive", "mean"),
-  opt.crit = c("mse", "mae"),
+  opt_alpha = FALSE,
+  opt_crit = c("mse", "mae"),
   x = y
 ) {
   fit <- croston_model(
     x,
     alpha = alpha,
     type = type,
-    init = init,
-    opt.crit = opt.crit
+    opt_alpha = opt_alpha,
+    opt_crit = opt_crit
   )
   fit$series <- deparse1(substitute(y))
   forecast(fit, h = h)

--- a/R/croston.R
+++ b/R/croston.R
@@ -35,6 +35,13 @@
 #'   the supplied `alpha` value(s) directly.
 #' @param opt_crit Optimization criterion used when `opt_alpha = TRUE`. Either
 #'   `"mse"` (mean squared error) or `"mae"` (mean absolute error).
+#' @param init Initial values for the demand and interval SES applications.
+#'   Either a string giving the initialization method (`"naive"`, the default,
+#'   initializes the interval to the first interval; `"mean"` to the mean of
+#'   the intervals; both initialize the demand to the first non-zero value), or
+#'   a numeric vector of length 2 giving the initial demand and interval
+#'   directly. When `opt_alpha = TRUE`, string-derived initial values are
+#'   optimized jointly with `alpha`, while numeric values are held fixed.
 #' @references Croston, J. (1972) "Forecasting and stock control for
 #' intermittent demands", \emph{Operational Research Quarterly}, \bold{23}(3),
 #' 289-303.
@@ -60,7 +67,8 @@ croston_model <- function(
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
   opt_alpha = FALSE,
-  opt_crit = c("mse", "mae")
+  opt_crit = c("mse", "mae"),
+  init = c("naive", "mean")
 ) {
   type <- match.arg(type)
   opt_crit <- match.arg(opt_crit)
@@ -82,40 +90,78 @@ croston_model <- function(
   y_demand <- y[non_zero]
   y_interval <- c(non_zero[1], diff(non_zero))
   n <- length(y)
+  if (is.numeric(init)) {
+    if (length(init) != 2) {
+      stop("init must be a numeric vector of length 2 (demand, interval)")
+    }
+    if (init[1] < 0) {
+      stop("initial demand must be non-negative")
+    }
+    if (init[2] < 1) {
+      stop("initial interval must be at least 1")
+    }
+    init_demand <- init[1]
+    init_interval <- init[2]
+    opt_init <- FALSE
+  } else {
+    init <- match.arg(init)
+    init_demand <- y_demand[1]
+    init_interval <- if (init == "mean") mean(y_interval) else y_interval[1]
+    opt_init <- TRUE
+  }
   alpha_demand <- alpha[1]
   alpha_interval <- alpha[length(alpha)]
   if (opt_alpha) {
-    separate <- length(alpha) == 2
-    par <- if (separate) c(alpha_demand, alpha_interval) else alpha_demand
+    n_alpha <- length(alpha)
+    # Only optimize the interval initial when more than one interval is feasible
+    opt_interval <- opt_init && max(y_interval) > 1
+    par <- c(alpha, if (opt_init) init_demand, if (opt_interval) init_interval)
+    lower <- c(rep(0, n_alpha), if (opt_init) 0, if (opt_interval) 1)
+    upper <- c(
+      rep(1, n_alpha),
+      if (opt_init) max(y_demand),
+      if (opt_interval) max(y_interval)
+    )
     opt <- optim(
       par = par,
       fn = function(par) {
         croston_cost(
           alpha_demand = par[1],
-          alpha_interval = par[length(par)],
+          alpha_interval = par[n_alpha],
           y = y,
           y_demand = y_demand,
           y_interval = y_interval,
+          init_demand = if (opt_init) par[n_alpha + 1] else init_demand,
+          init_interval = if (opt_interval) par[length(par)] else init_interval,
           non_zero = non_zero,
           n = n,
           type = type,
           opt_crit = opt_crit
         )
       },
-      lower = 0,
-      upper = 1,
+      lower = lower,
+      upper = upper,
       method = "L-BFGS-B",
       control = list(maxit = 2000)
     )
-    alpha <- opt$par
+    par <- opt$par
+    alpha <- par[seq_len(n_alpha)]
     alpha_demand <- alpha[1]
-    alpha_interval <- alpha[length(alpha)]
+    alpha_interval <- alpha[n_alpha]
+    if (opt_init) {
+      init_demand <- par[n_alpha + 1]
+    }
+    if (opt_interval) {
+      init_interval <- par[length(par)]
+    }
   }
   res <- croston_estimate(
     alpha_demand,
     alpha_interval,
     y_demand,
     y_interval,
+    init_demand,
+    init_interval,
     non_zero,
     n,
     type
@@ -123,6 +169,8 @@ croston_model <- function(
   output <- list(
     alpha = alpha,
     type = type,
+    init_demand = init_demand,
+    init_interval = init_interval,
     y = y,
     fit_demand = res$fit_demand,
     fit_interval = res$fit_interval,
@@ -140,6 +188,8 @@ croston_estimate <- function(
   alpha_interval,
   y_demand,
   y_interval,
+  init_demand,
+  init_interval,
   non_zero,
   n,
   type
@@ -147,8 +197,8 @@ croston_estimate <- function(
   k <- length(y_demand)
   fit_demand <- numeric(k)
   fit_interval <- numeric(k)
-  fit_demand[1] <- y_demand[1]
-  fit_interval[1] <- y_interval[1]
+  fit_demand[1] <- init_demand
+  fit_interval[1] <- init_interval
   for (i in 2:k) {
     fit_demand[i] <- fit_demand[i - 1] +
       alpha_demand * (y_demand[i] - fit_demand[i - 1])
@@ -178,6 +228,8 @@ croston_cost <- function(
   y,
   y_demand,
   y_interval,
+  init_demand,
+  init_interval,
   non_zero,
   n,
   type,
@@ -188,6 +240,8 @@ croston_cost <- function(
     alpha_interval,
     y_demand,
     y_interval,
+    init_demand,
+    init_interval,
     non_zero,
     n,
     type
@@ -219,6 +273,13 @@ print.croston_model <- function(
     cat("alpha:", format(x$alpha, digits = digits), "\n")
   }
   cat("method:", x$type, "\n")
+  cat(
+    "initial: demand =",
+    format(x$init_demand, digits = digits),
+    ", interval =",
+    format(x$init_interval, digits = digits),
+    "\n"
+  )
   invisible(x)
 }
 
@@ -295,6 +356,7 @@ croston <- function(
   type = c("croston", "sba", "sbj"),
   opt_alpha = FALSE,
   opt_crit = c("mse", "mae"),
+  init = c("naive", "mean"),
   x = y
 ) {
   fit <- croston_model(
@@ -302,7 +364,8 @@ croston <- function(
     alpha = alpha,
     type = type,
     opt_alpha = opt_alpha,
-    opt_crit = opt_crit
+    opt_crit = opt_crit,
+    init = init
   )
   fit$series <- deparse1(substitute(y))
   forecast(fit, h = h)

--- a/man/croston_model.Rd
+++ b/man/croston_model.Rd
@@ -4,16 +4,31 @@
 \alias{croston_model}
 \title{Croston forecast model}
 \usage{
-croston_model(y, alpha = 0.1, type = c("croston", "sba", "sbj"))
+croston_model(
+  y,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae")
+)
 }
 \arguments{
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1.}
+\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and initial values are
+jointly optimized.}
 
 \item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"} for
 Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
 approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
+
+\item{init}{Either a string specifying the initialization method for the SES components
+(\code{"naive"} or \code{"mean"}), or a numeric vector of length 2 giving the initial values for
+demand and interval respectively. When a string is used, demand is initialized to the first
+non-zero value and interval is initialized using the selected method. String values are used as
+starting points for optimization when \code{alpha = NULL}; numeric values are fixed.}
+
+\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"} or \code{"mae"}.}
 }
 \value{
 An object of class \code{croston_model}

--- a/man/croston_model.Rd
+++ b/man/croston_model.Rd
@@ -9,7 +9,8 @@ croston_model(
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
   opt_alpha = FALSE,
-  opt_crit = c("mse", "mae")
+  opt_crit = c("mse", "mae"),
+  init = c("naive", "mean")
 )
 }
 \arguments{
@@ -34,6 +35,14 @@ the supplied \code{alpha} value(s) directly.}
 
 \item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
 \code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
+
+\item{init}{Initial values for the demand and interval SES applications.
+Either a string giving the initialization method (\code{"naive"}, the default,
+initializes the interval to the first interval; \code{"mean"} to the mean of
+the intervals; both initialize the demand to the first non-zero value), or
+a numeric vector of length 2 giving the initial demand and interval
+directly. When \code{opt_alpha = TRUE}, string-derived initial values are
+optimized jointly with \code{alpha}, while numeric values are held fixed.}
 }
 \value{
 An object of class \code{croston_model}

--- a/man/croston_model.Rd
+++ b/man/croston_model.Rd
@@ -16,33 +16,27 @@ croston_model(
 \arguments{
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Smoothing parameter. A single value (the default, \code{0.1}) uses
-the same smoothing parameter for both the demand and interval SES
-applications. A numeric vector of length 2 uses separate parameters, with
-\code{alpha[1]} for the demand and \code{alpha[2]} for the interval. Each value must
-be between 0 and 1.}
+\item{alpha}{Smoothing parameter(s), each between 0 and 1. A single value
+(the default, \code{0.1}) is shared by the demand and interval SES applications. A
+length-2 vector uses \code{alpha[1]} for the demand and \code{alpha[2]} for the
+interval.}
 
-\item{type}{Which variant of Croston's method to use. Defaults to
-\code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
-Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
-method.}
+\item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"}
+for Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
+approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
 
-\item{opt_alpha}{If \code{TRUE}, the smoothing parameter(s) are optimized, using
-the supplied \code{alpha} value(s) as starting points. A single \code{alpha}
-optimizes one shared parameter, while a length-2 \code{alpha} optimizes the
-demand and interval parameters separately. Defaults to \code{FALSE}, which uses
-the supplied \code{alpha} value(s) directly.}
+\item{opt_alpha}{If \code{TRUE}, optimize the smoothing parameter(s) starting from
+\code{alpha}. Defaults to \code{FALSE}, which uses \code{alpha} directly.}
 
-\item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
-\code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
+\item{opt_crit}{Optimization criterion when \code{opt_alpha = TRUE}. One of \code{"mse"}
+(mean squared error) or \code{"mae"} (mean absolute error).}
 
-\item{init}{Initial values for the demand and interval SES applications.
-Either a string giving the initialization method (\code{"naive"}, the default,
-initializes the interval to the first interval; \code{"mean"} to the mean of
-the intervals; both initialize the demand to the first non-zero value), or
-a numeric vector of length 2 giving the initial demand and interval
-directly. When \code{opt_alpha = TRUE}, string-derived initial values are
-optimized jointly with \code{alpha}, while numeric values are held fixed.}
+\item{init}{Initial demand and interval values. Either a string method or a
+length-2 numeric \code{c(demand, interval)}. The \code{"naive"} method (the default)
+takes the interval from the first interval and \code{"mean"} from the mean
+interval, both taking demand from the first non-zero value. String values are
+optimized alongside \code{alpha} when \code{opt_alpha = TRUE}, while numeric values are
+held fixed.}
 }
 \value{
 An object of class \code{croston_model}

--- a/man/croston_model.Rd
+++ b/man/croston_model.Rd
@@ -8,31 +8,32 @@ croston_model(
   y,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
-  init = c("naive", "mean"),
-  opt.crit = c("mse", "mae")
+  opt_alpha = FALSE,
+  opt_crit = c("mse", "mae")
 )
 }
 \arguments{
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and
-initial values are jointly optimized.}
+\item{alpha}{Smoothing parameter. A single value (the default, \code{0.1}) uses
+the same smoothing parameter for both the demand and interval SES
+applications. A numeric vector of length 2 uses separate parameters, with
+\code{alpha[1]} for the demand and \code{alpha[2]} for the interval. Each value must
+be between 0 and 1.}
 
 \item{type}{Which variant of Croston's method to use. Defaults to
 \code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
 Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
 method.}
 
-\item{init}{Either a string specifying the initialization method for the
-SES components (\code{"naive"} or \code{"mean"}), or a numeric vector of length 2
-giving the initial values for demand and interval respectively. When a
-string is used, demand is initialized to the first non-zero value and
-interval is initialized using the selected method. String values are used
-as starting points for optimization when \code{alpha = NULL}; numeric values
-are fixed.}
+\item{opt_alpha}{If \code{TRUE}, the smoothing parameter(s) are optimized, using
+the supplied \code{alpha} value(s) as starting points. A single \code{alpha}
+optimizes one shared parameter, while a length-2 \code{alpha} optimizes the
+demand and interval parameters separately. Defaults to \code{FALSE}, which uses
+the supplied \code{alpha} value(s) directly.}
 
-\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"}
-or \code{"mae"}.}
+\item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
+\code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
 }
 \value{
 An object of class \code{croston_model}

--- a/man/croston_model.Rd
+++ b/man/croston_model.Rd
@@ -4,16 +4,35 @@
 \alias{croston_model}
 \title{Croston forecast model}
 \usage{
-croston_model(y, alpha = 0.1, type = c("croston", "sba", "sbj"))
+croston_model(
+  y,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae")
+)
 }
 \arguments{
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1.}
+\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and
+initial values are jointly optimized.}
 
-\item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"} for
-Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
-approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
+\item{type}{Which variant of Croston's method to use. Defaults to
+\code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
+Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
+method.}
+
+\item{init}{Either a string specifying the initialization method for the
+SES components (\code{"naive"} or \code{"mean"}), or a numeric vector of length 2
+giving the initial values for demand and interval respectively. When a
+string is used, demand is initialized to the first non-zero value and
+interval is initialized using the selected method. String values are used
+as starting points for optimization when \code{alpha = NULL}; numeric values
+are fixed.}
+
+\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"}
+or \code{"mae"}.}
 }
 \value{
 An object of class \code{croston_model}

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -7,7 +7,15 @@
 \usage{
 \method{forecast}{croston_model}(object, h = 10, ...)
 
-croston(y, h = 10, alpha = 0.1, type = c("croston", "sba", "sbj"), x = y)
+croston(
+  y,
+  h = 10,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae"),
+  x = y
+)
 }
 \arguments{
 \item{object}{An object of class \code{croston_model} as returned by \code{\link[=croston_model]{croston_model()}}.}
@@ -23,11 +31,20 @@ modelling function.}
 
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1.}
+\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and initial values are
+jointly optimized.}
 
 \item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"} for
 Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
 approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
+
+\item{init}{Either a string specifying the initialization method for the SES components
+(\code{"naive"} or \code{"mean"}), or a numeric vector of length 2 giving the initial values for
+demand and interval respectively. When a string is used, demand is initialized to the first
+non-zero value and interval is initialized using the selected method. String values are used as
+starting points for optimization when \code{alpha = NULL}; numeric values are fixed.}
+
+\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"} or \code{"mae"}.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 }

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -32,33 +32,27 @@ modelling function.}
 
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Smoothing parameter. A single value (the default, \code{0.1}) uses
-the same smoothing parameter for both the demand and interval SES
-applications. A numeric vector of length 2 uses separate parameters, with
-\code{alpha[1]} for the demand and \code{alpha[2]} for the interval. Each value must
-be between 0 and 1.}
+\item{alpha}{Smoothing parameter(s), each between 0 and 1. A single value
+(the default, \code{0.1}) is shared by the demand and interval SES applications. A
+length-2 vector uses \code{alpha[1]} for the demand and \code{alpha[2]} for the
+interval.}
 
-\item{type}{Which variant of Croston's method to use. Defaults to
-\code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
-Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
-method.}
+\item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"}
+for Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
+approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
 
-\item{opt_alpha}{If \code{TRUE}, the smoothing parameter(s) are optimized, using
-the supplied \code{alpha} value(s) as starting points. A single \code{alpha}
-optimizes one shared parameter, while a length-2 \code{alpha} optimizes the
-demand and interval parameters separately. Defaults to \code{FALSE}, which uses
-the supplied \code{alpha} value(s) directly.}
+\item{opt_alpha}{If \code{TRUE}, optimize the smoothing parameter(s) starting from
+\code{alpha}. Defaults to \code{FALSE}, which uses \code{alpha} directly.}
 
-\item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
-\code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
+\item{opt_crit}{Optimization criterion when \code{opt_alpha = TRUE}. One of \code{"mse"}
+(mean squared error) or \code{"mae"} (mean absolute error).}
 
-\item{init}{Initial values for the demand and interval SES applications.
-Either a string giving the initialization method (\code{"naive"}, the default,
-initializes the interval to the first interval; \code{"mean"} to the mean of
-the intervals; both initialize the demand to the first non-zero value), or
-a numeric vector of length 2 giving the initial demand and interval
-directly. When \code{opt_alpha = TRUE}, string-derived initial values are
-optimized jointly with \code{alpha}, while numeric values are held fixed.}
+\item{init}{Initial demand and interval values. Either a string method or a
+length-2 numeric \code{c(demand, interval)}. The \code{"naive"} method (the default)
+takes the interval from the first interval and \code{"mean"} from the mean
+interval, both taking demand from the first non-zero value. String values are
+optimized alongside \code{alpha} when \code{opt_alpha = TRUE}, while numeric values are
+held fixed.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 }

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -14,6 +14,7 @@ croston(
   type = c("croston", "sba", "sbj"),
   opt_alpha = FALSE,
   opt_crit = c("mse", "mae"),
+  init = c("naive", "mean"),
   x = y
 )
 }
@@ -50,6 +51,14 @@ the supplied \code{alpha} value(s) directly.}
 
 \item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
 \code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
+
+\item{init}{Initial values for the demand and interval SES applications.
+Either a string giving the initialization method (\code{"naive"}, the default,
+initializes the interval to the first interval; \code{"mean"} to the mean of
+the intervals; both initialize the demand to the first non-zero value), or
+a numeric vector of length 2 giving the initial demand and interval
+directly. When \code{opt_alpha = TRUE}, string-derived initial values are
+optimized jointly with \code{alpha}, while numeric values are held fixed.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 }

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -7,7 +7,15 @@
 \usage{
 \method{forecast}{croston_model}(object, h = 10, ...)
 
-croston(y, h = 10, alpha = 0.1, type = c("croston", "sba", "sbj"), x = y)
+croston(
+  y,
+  h = 10,
+  alpha = 0.1,
+  type = c("croston", "sba", "sbj"),
+  init = c("naive", "mean"),
+  opt.crit = c("mse", "mae"),
+  x = y
+)
 }
 \arguments{
 \item{object}{An object of class \code{croston_model} as returned by \code{\link[=croston_model]{croston_model()}}.}
@@ -23,11 +31,24 @@ modelling function.}
 
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1.}
+\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and
+initial values are jointly optimized.}
 
-\item{type}{Which variant of Croston's method to use. Defaults to \code{"croston"} for
-Croston's method, but can also be set to \code{"sba"} for the Syntetos-Boylan
-approximation, and \code{"sbj"} for the Shale-Boylan-Johnston method.}
+\item{type}{Which variant of Croston's method to use. Defaults to
+\code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
+Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
+method.}
+
+\item{init}{Either a string specifying the initialization method for the
+SES components (\code{"naive"} or \code{"mean"}), or a numeric vector of length 2
+giving the initial values for demand and interval respectively. When a
+string is used, demand is initialized to the first non-zero value and
+interval is initialized using the selected method. String values are used
+as starting points for optimization when \code{alpha = NULL}; numeric values
+are fixed.}
+
+\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"}
+or \code{"mae"}.}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 }

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -12,10 +12,10 @@ croston(
   h = 10,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
+  x = y,
   opt_alpha = FALSE,
   opt_crit = c("mse", "mae"),
-  init = c("naive", "mean"),
-  x = y
+  init = c("naive", "mean")
 )
 }
 \arguments{

--- a/man/forecast.croston_model.Rd
+++ b/man/forecast.croston_model.Rd
@@ -12,8 +12,8 @@ croston(
   h = 10,
   alpha = 0.1,
   type = c("croston", "sba", "sbj"),
-  init = c("naive", "mean"),
-  opt.crit = c("mse", "mae"),
+  opt_alpha = FALSE,
+  opt_crit = c("mse", "mae"),
   x = y
 )
 }
@@ -31,24 +31,25 @@ modelling function.}
 
 \item{y}{a numeric vector or univariate time series of class \code{ts}}
 
-\item{alpha}{Value of alpha. Default value is 0.1. If \code{NULL}, the alpha and
-initial values are jointly optimized.}
+\item{alpha}{Smoothing parameter. A single value (the default, \code{0.1}) uses
+the same smoothing parameter for both the demand and interval SES
+applications. A numeric vector of length 2 uses separate parameters, with
+\code{alpha[1]} for the demand and \code{alpha[2]} for the interval. Each value must
+be between 0 and 1.}
 
 \item{type}{Which variant of Croston's method to use. Defaults to
 \code{"croston"} for Croston's method, but can also be set to \code{"sba"} for the
 Syntetos-Boylan approximation, and \code{"sbj"} for the Shale-Boylan-Johnston
 method.}
 
-\item{init}{Either a string specifying the initialization method for the
-SES components (\code{"naive"} or \code{"mean"}), or a numeric vector of length 2
-giving the initial values for demand and interval respectively. When a
-string is used, demand is initialized to the first non-zero value and
-interval is initialized using the selected method. String values are used
-as starting points for optimization when \code{alpha = NULL}; numeric values
-are fixed.}
+\item{opt_alpha}{If \code{TRUE}, the smoothing parameter(s) are optimized, using
+the supplied \code{alpha} value(s) as starting points. A single \code{alpha}
+optimizes one shared parameter, while a length-2 \code{alpha} optimizes the
+demand and interval parameters separately. Defaults to \code{FALSE}, which uses
+the supplied \code{alpha} value(s) directly.}
 
-\item{opt.crit}{Optimization criterion when \code{alpha = NULL}. Either \code{"mse"}
-or \code{"mae"}.}
+\item{opt_crit}{Optimization criterion used when \code{opt_alpha = TRUE}. Either
+\code{"mse"} (mean squared error) or \code{"mae"} (mean absolute error).}
 
 \item{x}{Deprecated. Included for backwards compatibility.}
 }
@@ -65,7 +66,8 @@ described in Shenstone and Hyndman (2005). Croston's method involves using
 simple exponential smoothing (SES) on the non-zero elements of the time
 series and a separate application of SES to the times between non-zero
 elements of the time series. The smoothing parameters of the two
-applications of SES are assumed to be equal and are denoted by \code{alpha}.
+applications of SES are denoted by \code{alpha}, and may be shared (the default)
+or specified separately for the demand and interval components.
 
 Note that prediction intervals are not computed as Croston's method has no
 underlying stochastic model.

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -17,6 +17,60 @@ test_that("croston_model with custom alpha", {
   expect_equal(fit$alpha, 0.5)
 })
 
+test_that("croston_model with optimized alpha", {
+  fit <- croston_model(y, alpha = NULL)
+  expect_s3_class(fit, "croston_model")
+  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
+  mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
+  mse_default <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
+  expect_lte(mse_opt, mse_default)
+})
+
+test_that("croston_model optimized alpha works with type variants", {
+  fit_sba <- croston_model(y, alpha = NULL, type = "sba")
+  fit_sbj <- croston_model(y, alpha = NULL, type = "sbj")
+  expect_true(fit_sba$alpha >= 0 && fit_sba$alpha <= 1)
+  expect_true(fit_sbj$alpha >= 0 && fit_sbj$alpha <= 1)
+})
+
+test_that("croston_model with mean initialization", {
+  fit_mean <- croston_model(y, init = "mean")
+  fit_naive <- croston_model(y, init = "naive")
+  expect_equal(fit_mean$init, "mean")
+  expect_equal(fit_naive$init, "naive")
+  expect_false(identical(fit_mean$fitted, fit_naive$fitted))
+})
+
+test_that("croston_model with numeric init", {
+  fit <- croston_model(y, init = c(3, 2))
+  expect_equal(fit$init, c(3, 2))
+  expect_equal(fit$fit_demand[1], 3)
+  expect_equal(fit$fit_interval[1], 2)
+})
+
+test_that("croston_model with numeric init and optimized alpha", {
+  fit <- croston_model(y, alpha = NULL, init = c(3, 2))
+  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
+  expect_equal(fit$fit_demand[1], 3)
+  expect_equal(fit$fit_interval[1], 2)
+})
+
+test_that("croston_model errors on invalid init", {
+  expect_error(croston_model(y, init = c(3)), "length 2")
+  expect_error(croston_model(y, init = c(-1, 2)), "non-negative")
+  expect_error(croston_model(y, init = c(3, 0.5)), "at least 1")
+})
+
+test_that("croston_model with mae optimization", {
+  fit_mse <- croston_model(y, alpha = NULL, opt.crit = "mse")
+  fit_mae <- croston_model(y, alpha = NULL, opt.crit = "mae")
+  expect_true(fit_mse$alpha >= 0 && fit_mse$alpha <= 1)
+  expect_true(fit_mae$alpha >= 0 && fit_mae$alpha <= 1)
+  mae_mae <- mean(abs(fit_mae$residuals), na.rm = TRUE)
+  mae_mse <- mean(abs(fit_mse$residuals), na.rm = TRUE)
+  expect_lte(mae_mae, mae_mse)
+})
+
 test_that("croston_model type variants", {
   fit_cr <- croston_model(y, type = "croston")
   fit_sba <- croston_model(y, type = "sba")
@@ -66,6 +120,11 @@ test_that("croston shortcut", {
   fc <- croston(y, h = 5)
   expect_s3_class(fc, "forecast")
   expect_length(fc$mean, 5)
+})
+
+test_that("croston shortcut passes init and opt.crit", {
+  fc <- croston(y, alpha = NULL, init = "mean", opt.crit = "mae")
+  expect_s3_class(fc, "forecast")
 })
 
 test_that("croston shortcut with type variants", {

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -50,6 +50,35 @@ test_that("croston_model optimized alpha works with type variants", {
   expect_true(fit_sbj$alpha >= 0 && fit_sbj$alpha <= 1)
 })
 
+test_that("croston_model optimizes initial values with alpha", {
+  fit <- croston_model(y, opt_alpha = TRUE)
+  nz <- which(y != 0)
+  # initial values should move away from the naive starting points
+  expect_false(fit$init_demand == y[nz[1]])
+  expect_false(fit$init_interval == nz[1])
+  mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
+  mse_alpha_only <- mean(
+    croston_model(y, opt_alpha = TRUE, init = c(y[nz[1]], nz[1]))$residuals^2,
+    na.rm = TRUE
+  )
+  expect_lte(mse_opt, mse_alpha_only)
+})
+
+test_that("croston_model with fixed numeric init", {
+  fit <- croston_model(y, init = c(2, 4))
+  expect_equal(fit$init_demand, 2)
+  expect_equal(fit$init_interval, 4)
+  fit_opt <- croston_model(y, opt_alpha = TRUE, init = c(2, 4))
+  expect_equal(fit_opt$init_demand, 2)
+  expect_equal(fit_opt$init_interval, 4)
+})
+
+test_that("croston_model with mean init", {
+  fit <- croston_model(y, init = "mean")
+  nz <- which(y != 0)
+  expect_equal(fit$init_interval, mean(c(nz[1], diff(nz))))
+})
+
 test_that("croston_model with mae optimization", {
   fit_mse <- croston_model(y, opt_alpha = TRUE, opt_crit = "mse")
   fit_mae <- croston_model(y, opt_alpha = TRUE, opt_crit = "mae")
@@ -78,6 +107,12 @@ test_that("croston_model errors on invalid input", {
   expect_error(croston_model(y, alpha = -0.1), "alpha must be between 0 and 1")
   expect_error(croston_model(y, alpha = 1.5), "alpha must be between 0 and 1")
   expect_error(croston_model(y, alpha = c(0.1, 0.2, 0.3)), "length 1 or 2")
+  expect_error(croston_model(y, init = c(1, 2, 3)), "length 2")
+  expect_error(croston_model(y, init = c(-1, 2)), "demand must be non-negative")
+  expect_error(
+    croston_model(y, init = c(1, 0.5)),
+    "interval must be at least 1"
+  )
   expect_error(croston_model(c(-1, 2, 0)), "non-negative data")
   expect_error(croston_model(c(0, 0, 1, 0)), "At least two non-zero values")
   expect_error(croston_model(c(0, 0, 0)), "At least two non-zero values")

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -17,63 +17,42 @@ test_that("croston_model with custom alpha", {
   expect_equal(fit$alpha, 0.5)
 })
 
+test_that("croston_model with separate alphas", {
+  fit <- croston_model(y, alpha = c(0.3, 0.2))
+  expect_equal(fit$alpha, c(0.3, 0.2))
+  fit_shared <- croston_model(y, alpha = 0.3)
+  expect_false(identical(fit$fitted, fit_shared$fitted))
+})
+
 test_that("croston_model with optimized alpha", {
-  fit <- croston_model(y, alpha = NULL)
+  fit <- croston_model(y, opt_alpha = TRUE)
   expect_s3_class(fit, "croston_model")
+  expect_length(fit$alpha, 1)
   expect_true(fit$alpha >= 0 && fit$alpha <= 1)
   mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
   mse_default <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
   expect_lte(mse_opt, mse_default)
 })
 
+test_that("croston_model with optimized separate alphas", {
+  fit <- croston_model(y, alpha = c(0.1, 0.1), opt_alpha = TRUE)
+  expect_length(fit$alpha, 2)
+  expect_true(all(fit$alpha >= 0 & fit$alpha <= 1))
+  mse_two <- mean(fit$residuals^2, na.rm = TRUE)
+  mse_one <- mean(croston_model(y, opt_alpha = TRUE)$residuals^2, na.rm = TRUE)
+  expect_lte(mse_two, mse_one)
+})
+
 test_that("croston_model optimized alpha works with type variants", {
-  fit_sba <- croston_model(y, alpha = NULL, type = "sba")
-  fit_sbj <- croston_model(y, alpha = NULL, type = "sbj")
+  fit_sba <- croston_model(y, opt_alpha = TRUE, type = "sba")
+  fit_sbj <- croston_model(y, opt_alpha = TRUE, type = "sbj")
   expect_true(fit_sba$alpha >= 0 && fit_sba$alpha <= 1)
   expect_true(fit_sbj$alpha >= 0 && fit_sbj$alpha <= 1)
 })
 
-test_that("croston_model with mean initialization", {
-  fit_mean <- croston_model(y, init = "mean")
-  fit_naive <- croston_model(y, init = "naive")
-  expect_equal(fit_mean$init, "mean")
-  expect_equal(fit_naive$init, "naive")
-  expect_false(identical(fit_mean$fitted, fit_naive$fitted))
-})
-
-test_that("croston_model with numeric init", {
-  fit <- croston_model(y, init = c(3, 2))
-  expect_equal(fit$init, c(3, 2))
-  expect_equal(fit$fit_demand[1], 3)
-  expect_equal(fit$fit_interval[1], 2)
-})
-
-test_that("croston_model with numeric init and optimized alpha", {
-  fit <- croston_model(y, alpha = NULL, init = c(3, 2))
-  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
-  expect_equal(fit$fit_demand[1], 3)
-  expect_equal(fit$fit_interval[1], 2)
-})
-
-test_that("croston_model stores resolved initial values", {
-  fit <- croston_model(y, init = c(3, 2))
-  expect_equal(fit$init_demand, 3)
-  expect_equal(fit$init_interval, 2)
-
-  fit_opt <- croston_model(y, alpha = NULL, init = "mean")
-  expect_equal(fit_opt$init_demand, fit_opt$fit_demand[1])
-  expect_equal(fit_opt$init_interval, fit_opt$fit_interval[1])
-})
-
-test_that("croston_model errors on invalid init", {
-  expect_error(croston_model(y, init = c(3)), "length 2")
-  expect_error(croston_model(y, init = c(-1, 2)), "non-negative")
-  expect_error(croston_model(y, init = c(3, 0.5)), "at least 1")
-})
-
 test_that("croston_model with mae optimization", {
-  fit_mse <- croston_model(y, alpha = NULL, opt.crit = "mse")
-  fit_mae <- croston_model(y, alpha = NULL, opt.crit = "mae")
+  fit_mse <- croston_model(y, opt_alpha = TRUE, opt_crit = "mse")
+  fit_mae <- croston_model(y, opt_alpha = TRUE, opt_crit = "mae")
   expect_true(fit_mse$alpha >= 0 && fit_mse$alpha <= 1)
   expect_true(fit_mae$alpha >= 0 && fit_mae$alpha <= 1)
   mae_mae <- mean(abs(fit_mae$residuals), na.rm = TRUE)
@@ -98,6 +77,7 @@ test_that("croston_model type variants", {
 test_that("croston_model errors on invalid input", {
   expect_error(croston_model(y, alpha = -0.1), "alpha must be between 0 and 1")
   expect_error(croston_model(y, alpha = 1.5), "alpha must be between 0 and 1")
+  expect_error(croston_model(y, alpha = c(0.1, 0.2, 0.3)), "length 1 or 2")
   expect_error(croston_model(c(-1, 2, 0)), "non-negative data")
   expect_error(croston_model(c(0, 0, 1, 0)), "At least two non-zero values")
   expect_error(croston_model(c(0, 0, 0)), "At least two non-zero values")
@@ -133,8 +113,8 @@ test_that("croston shortcut", {
   expect_length(fc$mean, 5)
 })
 
-test_that("croston shortcut passes init and opt.crit", {
-  fc <- croston(y, alpha = NULL, init = "mean", opt.crit = "mae")
+test_that("croston shortcut passes opt_alpha and opt_crit", {
+  fc <- croston(y, opt_alpha = TRUE, opt_crit = "mae")
   expect_s3_class(fc, "forecast")
 })
 

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -17,6 +17,60 @@ test_that("croston_model with custom alpha", {
   expect_equal(fit$alpha, 0.5)
 })
 
+test_that("croston_model with optimized alpha", {
+  fit <- croston_model(y, alpha = NULL)
+  expect_s3_class(fit, "croston_model")
+  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
+  mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
+  mse_default <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
+  expect_lte(mse_opt, mse_default)
+})
+
+test_that("croston_model optimized alpha works with type variants", {
+  fit_sba <- croston_model(y, alpha = NULL, type = "sba")
+  fit_sbj <- croston_model(y, alpha = NULL, type = "sbj")
+  expect_true(fit_sba$alpha >= 0 && fit_sba$alpha <= 1)
+  expect_true(fit_sbj$alpha >= 0 && fit_sbj$alpha <= 1)
+})
+
+test_that("croston_model with mean initialization", {
+  fit_mean <- croston_model(y, init = "mean")
+  fit_naive <- croston_model(y, init = "naive")
+  expect_equal(fit_mean$init, "mean")
+  expect_equal(fit_naive$init, "naive")
+  expect_false(identical(fit_mean$fitted, fit_naive$fitted))
+})
+
+test_that("croston_model with numeric init", {
+  fit <- croston_model(y, init = c(3, 2))
+  expect_equal(fit$init, c(3, 2))
+  expect_equal(fit$fit_demand[1], 3)
+  expect_equal(fit$fit_interval[1], 2)
+})
+
+test_that("croston_model with numeric init and optimized alpha", {
+  fit <- croston_model(y, alpha = NULL, init = c(3, 2))
+  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
+  expect_equal(fit$fit_demand[1], 3)
+  expect_equal(fit$fit_interval[1], 2)
+})
+
+test_that("croston_model errors on invalid init", {
+  expect_error(croston_model(y, init = c(3)), "length 2")
+  expect_error(croston_model(y, init = c(-1, 2)), "non-negative")
+  expect_error(croston_model(y, init = c(3, 0.5)), "at least 1")
+})
+
+test_that("croston_model with mae optimization", {
+  fit_mse <- croston_model(y, alpha = NULL, opt.crit = "mse")
+  fit_mae <- croston_model(y, alpha = NULL, opt.crit = "mae")
+  expect_true(fit_mse$alpha >= 0 && fit_mse$alpha <= 1)
+  expect_true(fit_mae$alpha >= 0 && fit_mae$alpha <= 1)
+  mae_mae <- mean(abs(fit_mae$residuals), na.rm = TRUE)
+  mae_mse <- mean(abs(fit_mse$residuals), na.rm = TRUE)
+  expect_lte(mae_mae, mae_mse)
+})
+
 test_that("croston_model type variants", {
   fit_cr <- croston_model(y, type = "croston")
   fit_sba <- croston_model(y, type = "sba")
@@ -67,6 +121,11 @@ test_that("croston shortcut", {
   fc <- croston(y, h = 5)
   expect_s3_class(fc, "forecast")
   expect_length(fc$mean, 5)
+})
+
+test_that("croston shortcut passes init and opt.crit", {
+  fc <- croston(y, alpha = NULL, init = "mean", opt.crit = "mae")
+  expect_s3_class(fc, "forecast")
 })
 
 test_that("croston shortcut with type variants", {

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -55,6 +55,16 @@ test_that("croston_model with numeric init and optimized alpha", {
   expect_equal(fit$fit_interval[1], 2)
 })
 
+test_that("croston_model stores resolved initial values", {
+  fit <- croston_model(y, init = c(3, 2))
+  expect_equal(fit$init_demand, 3)
+  expect_equal(fit$init_interval, 2)
+
+  fit_opt <- croston_model(y, alpha = NULL, init = "mean")
+  expect_equal(fit_opt$init_demand, fit_opt$fit_demand[1])
+  expect_equal(fit_opt$init_interval, fit_opt$fit_interval[1])
+})
+
 test_that("croston_model errors on invalid init", {
   expect_error(croston_model(y, init = c(3)), "length 2")
   expect_error(croston_model(y, init = c(-1, 2)), "non-negative")

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -28,40 +28,52 @@ test_that("croston_model with optimized alpha", {
   fit <- croston_model(y, opt_alpha = TRUE)
   expect_s3_class(fit, "croston_model")
   expect_length(fit$alpha, 1)
-  expect_true(fit$alpha >= 0 && fit$alpha <= 1)
+  expect_gte(fit$alpha, 0)
+  expect_lte(fit$alpha, 1)
+  # optimization cannot worsen the fit vs its alpha = 0.1 starting point
   mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
-  mse_default <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
-  expect_lte(mse_opt, mse_default)
+  mse_start <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
+  expect_lte(mse_opt, mse_start)
 })
 
 test_that("croston_model with optimized separate alphas", {
   fit <- croston_model(y, alpha = c(0.1, 0.1), opt_alpha = TRUE)
   expect_length(fit$alpha, 2)
-  expect_true(all(fit$alpha >= 0 & fit$alpha <= 1))
+  expect_gte(min(fit$alpha), 0)
+  expect_lte(max(fit$alpha), 1)
+  # compare against the c(0.1, 0.1) start; a local optimum need not beat the
+  # separately optimized single-alpha fit
   mse_two <- mean(fit$residuals^2, na.rm = TRUE)
-  mse_one <- mean(croston_model(y, opt_alpha = TRUE)$residuals^2, na.rm = TRUE)
-  expect_lte(mse_two, mse_one)
+  mse_start <- mean(
+    croston_model(y, alpha = c(0.1, 0.1))$residuals^2,
+    na.rm = TRUE
+  )
+  expect_lte(mse_two, mse_start)
 })
 
 test_that("croston_model optimized alpha works with type variants", {
   fit_sba <- croston_model(y, opt_alpha = TRUE, type = "sba")
   fit_sbj <- croston_model(y, opt_alpha = TRUE, type = "sbj")
-  expect_true(fit_sba$alpha >= 0 && fit_sba$alpha <= 1)
-  expect_true(fit_sbj$alpha >= 0 && fit_sbj$alpha <= 1)
+  expect_gte(fit_sba$alpha, 0)
+  expect_lte(fit_sba$alpha, 1)
+  expect_gte(fit_sbj$alpha, 0)
+  expect_lte(fit_sbj$alpha, 1)
 })
 
 test_that("croston_model optimizes initial values with alpha", {
   fit <- croston_model(y, opt_alpha = TRUE)
   nz <- which(y != 0)
-  # initial values should move away from the naive starting points
-  expect_false(fit$init_demand == y[nz[1]])
-  expect_false(fit$init_interval == nz[1])
+  y_demand <- y[nz]
+  y_interval <- c(nz[1], diff(nz))
+  # optimized initial values stay within their feasible bounds
+  expect_gte(fit$init_demand, 0)
+  expect_lte(fit$init_demand, max(y_demand))
+  expect_gte(fit$init_interval, 1)
+  expect_lte(fit$init_interval, max(y_interval))
+  # optimizing alpha and init cannot worsen the fit vs the naive start
   mse_opt <- mean(fit$residuals^2, na.rm = TRUE)
-  mse_alpha_only <- mean(
-    croston_model(y, opt_alpha = TRUE, init = c(y[nz[1]], nz[1]))$residuals^2,
-    na.rm = TRUE
-  )
-  expect_lte(mse_opt, mse_alpha_only)
+  mse_start <- mean(croston_model(y, alpha = 0.1)$residuals^2, na.rm = TRUE)
+  expect_lte(mse_opt, mse_start)
 })
 
 test_that("croston_model with fixed numeric init", {
@@ -82,11 +94,20 @@ test_that("croston_model with mean init", {
 test_that("croston_model with mae optimization", {
   fit_mse <- croston_model(y, opt_alpha = TRUE, opt_crit = "mse")
   fit_mae <- croston_model(y, opt_alpha = TRUE, opt_crit = "mae")
-  expect_true(fit_mse$alpha >= 0 && fit_mse$alpha <= 1)
-  expect_true(fit_mae$alpha >= 0 && fit_mae$alpha <= 1)
-  mae_mae <- mean(abs(fit_mae$residuals), na.rm = TRUE)
-  mae_mse <- mean(abs(fit_mse$residuals), na.rm = TRUE)
-  expect_lte(mae_mae, mae_mse)
+  expect_gte(fit_mse$alpha, 0)
+  expect_lte(fit_mse$alpha, 1)
+  expect_gte(fit_mae$alpha, 0)
+  expect_lte(fit_mae$alpha, 1)
+  # each criterion cannot worsen its own metric vs the shared naive start
+  start <- croston_model(y, alpha = 0.1)
+  expect_lte(
+    mean(abs(fit_mae$residuals), na.rm = TRUE),
+    mean(abs(start$residuals), na.rm = TRUE)
+  )
+  expect_lte(
+    mean(fit_mse$residuals^2, na.rm = TRUE),
+    mean(start$residuals^2, na.rm = TRUE)
+  )
 })
 
 test_that("croston_model type variants", {


### PR DESCRIPTION
 - Backport some features from fable's `CROSTON()` to `croston_model()`
 - `alpha = NULL` jointly optimizes the smoothing parameter and initial values via `optim()`
 - New init parameter for interval component initialization ("naive" or "mean")
 - Fitted values before the first non-zero demand are now `NA` instead of 0, matching fable and tsintermittent

Note: one could change the default value for `initial` to "mean" to match the fable and tsintermittent implementation, but that would be somewhat breaking change.

Brief comparison to the fable NA handling:

```r
  library(forecast)
  library(fable)
  library(tsibble)
  library(tsintermittent)

  y <- c(0, 0, 0, 3, 0, 0, 2, 0, 5)

  # old: leading zeros get fitted = 0
  # fitted:  NA     0     0     0  0.75  0.75  0.75  0.7436  0.7436

  # new (fixed alpha): leading zeros are now NA
  croston_model(y, alpha = 0.1)$fitted
  #> NA    NA    NA    NA  0.75  0.75  0.75  0.7436  0.7436

  # new (optimized alpha + init values)
  fit <- croston_model(y, alpha = NULL)
  fit$alpha
  #> 0
  fit$fitted
  #> NA    NA    NA    NA  1.4  1.4  1.4  1.4  1.4

  # fable (optimized alpha + init values)
  tbl <- tsibble(t = 1:9, y = y, index = t)
  fit_fable <- tbl |> model(CROSTON(y ~ demand(param = 0.1) + interval(param = 0.1, method = "naive")))
  augment(fit_fable)$.fitted
  #> NA    NA    NA    NA  1.3648  1.3648  1.3648  1.3066  1.3066

  # tsintermittent (fixed alpha, optimized init values)
  crost(y, w = 0.1, type = "croston", init = "naive")$frc.in
  #> NA    NA    NA    NA  0.6111  0.6111  0.6111  0.625  0.625
  ```