### PR TITLE
fix(CVar): use y - fit convention for residuals

### DIFF
--- a/R/tscv.R
+++ b/R/tscv.R
@@ -241,7 +241,7 @@ CVar <- function(
   out$testfit <- ts(alltestfit)
   tsp(out$testfit) <- tsp(y)
 
-  out$residuals <- out$testfit - y
+  out$residuals <- y - out$testfit
   out$LBpvalue <- Box.test(out$residuals, type = "Ljung", lag = LBlags)$p.value
 
   out$k <- k


### PR DESCRIPTION
It doesn't change the `Box.test(..., type = "Ljung")` and makes it more accurate when the user wants to access the residuals of the object.