### PR TITLE
perf(ets): skip storing state path during optimisation

### DIFF
--- a/src/etsTargetFunction.cpp
+++ b/src/etsTargetFunction.cpp
@@ -138,11 +138,7 @@ void EtsTargetFunction::eval(const double *p_par, int p_par_length) {
     }
   };
 
-  const int p = state.size();
-
-  for (int i = 0; i <= p * this->y.size(); i++) state.push_back(0);
-
-  etscalc_internal(this->y.data(), this->n, this->state.data(), this->m,
+  etscalc_internal(this->y.data(), this->n, this->state.data(), nullptr, this->m,
                    this->errortype, this->trendtype, this->seasontype,
                    this->alpha, this->beta, this->gamma, this->phi,
                    this->e.data(), this->fits.data(), &this->lik,

--- a/src/etsTargetFunction.cpp
+++ b/src/etsTargetFunction.cpp
@@ -86,11 +86,7 @@ void EtsTargetFunction::eval(const double *p_par, int p_par_length) {
 
   if (equal) return;
 
-  this->par.clear();
-
-  for (int j = 0; j < p_par_length; j++) {
-    this->par.push_back(p_par[j]);
-  }
+  this->par.assign(p_par, p_par + p_par_length);
 
   int j = 0;
   if (optAlpha) this->alpha = par[j++];
@@ -103,11 +99,7 @@ void EtsTargetFunction::eval(const double *p_par, int p_par_length) {
     return;
   }
 
-  this->state.clear();
-
-  for (int i = par.size() - nstate; i < par.size(); i++) {
-    this->state.push_back(par[i]);
-  }
+  this->state.assign(par.end() - nstate, par.end());
 
   // Add extra state
   if (seasontype != 0) {

--- a/src/etsTargetFunction.h
+++ b/src/etsTargetFunction.h
@@ -3,8 +3,8 @@
 
 extern "C" {
 
-void etscalc_internal(const double *y, int n, double *x, int m, int error, int trend, int season,
-  double alpha, double beta, double gamma, double phi,
+void etscalc_internal(const double *y, int n, const double *x_init, double *states, int m,
+  int error, int trend, int season, double alpha, double beta, double gamma, double phi,
   double *e, double *fits, double *lik, double *amse, int nmse);
 
 void R_cpolyroot(double *opr, double *opi, int *degree,

--- a/src/etscalc.c
+++ b/src/etscalc.c
@@ -22,15 +22,15 @@ static void forecast(double l, double b, const double *s, int m, int trend,
 static void update(const double *oldl, double *l, const double *oldb, double *b,
   const double *olds, double *s, int m, int trend, int season,
   double alpha, double beta, double gamma, double phi, double y);
-void etscalc_internal(const double *y, int n, double *x, int m, int error, int trend, int season,
-  double alpha, double beta, double gamma, double phi,
+void etscalc_internal(const double *y, int n, const double *x_init, double *states, int m,
+  int error, int trend, int season, double alpha, double beta, double gamma, double phi,
   double *e, double *fits, double *lik, double *amse, int nmse);
 
 // ******************************************************************
 
-void etscalc_internal(const double *y, int n, double *x, int m, int error, int trend, int season,
-                      double alpha, double beta, double gamma, double phi,
-                      double *e, double *fits, double *lik, double *amse, int nmse) {
+void etscalc_internal(const double *y, int n, const double *x_init, double *states, int m,
+                      int error, int trend, int season, double alpha, double beta, double gamma,
+                      double phi, double *e, double *fits, double *lik, double *amse, int nmse) {
   double oldl, l, oldb = 0.0, b = 0.0, olds[24], s[24], f[30], lik2, tmp, denom[30];
 
   if (m > 24 && season > NONE)
@@ -44,11 +44,11 @@ void etscalc_internal(const double *y, int n, double *x, int m, int error, int t
   const int nstates = m * (season > NONE) + 1 + (trend > NONE);
 
   // Copy initial state components
-  l = x[0];
+  l = x_init[0];
   if (trend > NONE)
-    b = x[1];
+    b = x_init[1];
   if (season > NONE) {
-    memcpy(s, &x[(trend > NONE) + 1], m * sizeof(double));
+    memcpy(s, &x_init[(trend > NONE) + 1], m * sizeof(double));
   }
 
   *lik = 0.0;
@@ -96,11 +96,13 @@ void etscalc_internal(const double *y, int n, double *x, int m, int error, int t
     update(&oldl, &l, &oldb, &b, olds, s, m, trend, season, alpha, beta, gamma, phi, y[i]);
 
     // STORE NEW STATE
-    x[nstates * (i + 1)] = l;
-    if (trend > NONE)
-      x[nstates * (i + 1) + 1] = b;
-    if (season > NONE) {
-      memcpy(&x[(trend > NONE) + nstates * (i + 1) + 1], s, m * sizeof(double));
+    if (states != NULL) {
+      states[nstates * (i + 1)] = l;
+      if (trend > NONE)
+        states[nstates * (i + 1) + 1] = b;
+      if (season > NONE) {
+        memcpy(&states[(trend > NONE) + nstates * (i + 1) + 1], s, m * sizeof(double));
+      }
     }
     if (!R_IsNA(e[i]))
       *lik = *lik + e[i] * e[i];
@@ -136,7 +138,7 @@ SEXP etscalc(SEXP y, SEXP x, SEXP m, SEXP error, SEXP trend, SEXP season,
 
   double lik;
 
-  etscalc_internal(y_ptr, n_val, REAL(x_out), m_val, error_val, trend_val, season_val,
+  etscalc_internal(y_ptr, n_val, REAL_RO(x), REAL(x_out), m_val, error_val, trend_val, season_val,
                    alpha_val, beta_val, gamma_val, phi_val,
                    REAL(e_out), REAL(fits_out), &lik, REAL(amse_out), nmse_val);
 


### PR DESCRIPTION
Currently, the states output was never read during the optimization path and only reads the initial state. This makes the states write optional.

speedup (`bench::mark()` median): 
- 1.8× WWWusage
- 1.8× USAccDeaths
- 2.4× AirPassengers
- 2.4× wineind
- 3.9× co2 