### PR TITLE
fix(forecast.croston_model): forecast from final smoothed states

### DIFF
--- a/R/croston.R
+++ b/R/croston.R
@@ -86,7 +86,7 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
     y = y,
     fit_demand = fit_demand,
     fit_interval = fit_interval,
-    ratio = ratio,
+    ratio = ratio[k],
     fitted = fits,
     residuals = y - fits,
     series = series
@@ -154,7 +154,7 @@ forecast.croston_model <- function(object, h = 10, ...) {
   start <- tsp(object$y)[2] + 1 / m
   output <- list(
     mean = ts(
-      rep(object$ratio[length(object$ratio)], h),
+      rep(object$ratio, h),
       start = start,
       frequency = m
     ),

--- a/R/croston.R
+++ b/R/croston.R
@@ -86,6 +86,7 @@ croston_model <- function(y, alpha = 0.1, type = c("croston", "sba", "sbj")) {
     y = y,
     fit_demand = fit_demand,
     fit_interval = fit_interval,
+    ratio = ratio,
     fitted = fits,
     residuals = y - fits,
     series = series
@@ -151,16 +152,12 @@ print.croston_model <- function(
 forecast.croston_model <- function(object, h = 10, ...) {
   m <- frequency(object$y)
   start <- tsp(object$y)[2] + 1 / m
-  coeff <- switch(
-    object$type,
-    sba = 1 - object$alpha / 2,
-    sbj = 1 - object$alpha / (2 - object$alpha),
-    1
-  )
-  k <- length(object$fit_demand)
-  fc <- coeff * object$fit_demand[k] / object$fit_interval[k]
   output <- list(
-    mean = ts(rep(fc, h), start = start, frequency = m),
+    mean = ts(
+      rep(object$ratio[length(object$ratio)], h),
+      start = start,
+      frequency = m
+    ),
     x = object$y,
     fitted = object$fitted,
     residuals = object$residuals,

--- a/R/croston.R
+++ b/R/croston.R
@@ -151,12 +151,16 @@ print.croston_model <- function(
 forecast.croston_model <- function(object, h = 10, ...) {
   m <- frequency(object$y)
   start <- tsp(object$y)[2] + 1 / m
+  coeff <- switch(
+    object$type,
+    sba = 1 - object$alpha / 2,
+    sbj = 1 - object$alpha / (2 - object$alpha),
+    1
+  )
+  k <- length(object$fit_demand)
+  fc <- coeff * object$fit_demand[k] / object$fit_interval[k]
   output <- list(
-    mean = ts(
-      rep(object$fitted[length(object$fitted)], h),
-      start = start,
-      frequency = m
-    ),
+    mean = ts(rep(fc, h), start = start, frequency = m),
     x = object$y,
     fitted = object$fitted,
     residuals = object$residuals,

--- a/tests/testthat/test-croston.R
+++ b/tests/testthat/test-croston.R
@@ -51,7 +51,8 @@ test_that("forecast.croston_model", {
   expect_s3_class(fc, "forecast")
   expect_length(fc$mean, 12)
   expect_true(all(fc$mean == fc$mean[1]))
-  expect_equal(fc$mean[1], fit$fitted[length(y)])
+  k <- length(fit$fit_demand)
+  expect_equal(fc$mean[1], fit$fit_demand[k] / fit$fit_interval[k])
   expect_identical(fc$x, fit$y)
 })
 


### PR DESCRIPTION
Result was lagging by one update when the series ended with a non-zero demand.
I've just stored the var in the second commit instead of recalculating. One could also just store the last value of the ratio value, since it's the only entry that's being looked at. Let me know what you prefer.