### PR TITLE
fix(etscalc): correct damped trend sum in multi-step forecasts

### DIFF
--- a/src/etscalc.c
+++ b/src/etscalc.c
@@ -283,7 +283,7 @@ static void forecast(double l, double b, const double *s, int m, int trend,
       if (fabs(phi - 1.0) < TOL)
         phistar = phistar + 1.0;
       else
-        phistar = phistar + pow(phi, (double)(i + 1));
+        phistar = phistar + pow(phi, (double)(i + 2));
     }
   }
 }


### PR DESCRIPTION
forecast() extended the damping sum with phi^(i+1) instead of phi^(i+2), so horizon 2 used 2*phi*b instead of (phi + phi^2)*b. Affected simulation/bootstrap point forecasts and AMSE-based estimation.