### PR TITLE
fix(forecast.ets): correct seasonal disturbance index

### DIFF
--- a/R/etsforecast.R
+++ b/R/etsforecast.R
@@ -261,7 +261,7 @@ class1 <- function(
     G[2, 1] <- par["beta"]
   }
   if (seasontype == "A") {
-    G[3, 1] <- par["gamma"]
+    G[p - m + 1, 1] <- par["gamma"]
   }
   mu <- numeric(h)
   Fj <- diag(p)


### PR DESCRIPTION
Matches the seasonal indexing already used for the transition matrix, etc. Might make sense to put the seasonal start index in a variable since it's used in a few places.