### PR TITLE
perf: speed up BATS/TBATS prediction interval variance calculation

### DIFF
--- a/R/forecastBATS.R
+++ b/R/forecastBATS.R
@@ -42,8 +42,8 @@ forecast.bats <- function(
   } else {
     ts.frequency <- 1
   }
-  if(is.null(biasadj)) {
-    if(!is.null(object$lambda)) {
+  if (is.null(biasadj)) {
+    if (!is.null(object$lambda)) {
       biasadj <- attr(object$lambda, "biasadj")
     } else {
       biasadj <- FALSE
@@ -107,13 +107,10 @@ forecast.bats <- function(
   variance.multiplier <- numeric(h)
   variance.multiplier[1] <- 1
   if (h > 1) {
+    f.running.g <- g$g
     for (j in seq_len(h - 1)) {
-      if (j == 1) {
-        f.running <- diag(ncol(F))
-      } else {
-        f.running <- f.running %*% F
-      }
-      c.j <- w$w.transpose %*% f.running %*% g$g
+      c.j <- w$w.transpose %*% f.running.g
+      f.running.g <- F %*% f.running.g
       variance.multiplier[(j + 1)] <- variance.multiplier[j] + c.j^2
     }
   }

--- a/R/forecastTBATS.R
+++ b/R/forecastTBATS.R
@@ -110,17 +110,13 @@ forecast.tbats <- function(
   variance.multiplier <- numeric(h)
   variance.multiplier[1] <- 1
   if (h > 1) {
+    f.running.g <- g
     for (t in 2L:h) {
       x[, t] <- F %*% x[, (t - 1)]
       y.forecast[t] <- w$w.transpose %*% x[, (t - 1)]
-      j <- t - 1
-      if (j == 1) {
-        f.running <- diag(ncol(F))
-      } else {
-        f.running <- f.running %*% F
-      }
-      c.j <- w$w.transpose %*% f.running %*% g
-      variance.multiplier[j + 1] <- variance.multiplier[j] + c.j^2
+      c.j <- w$w.transpose %*% f.running.g
+      f.running.g <- F %*% f.running.g
+      variance.multiplier[t] <- variance.multiplier[t - 1] + c.j^2
     }
   }
   variance <- object$variance * variance.multiplier


### PR DESCRIPTION
Instead of accumulating the matrix power F^(j-1), the loop now accumulates the vector F^(j-1) g. Computes the same c_j values, but quite a bit cheaper.