### PR TITLE
fix(bats): update gamma.bold for all seasonal periods in updateGMatrix

### DIFF
--- a/src/updateMatrices.cpp
+++ b/src/updateMatrices.cpp
@@ -135,6 +135,7 @@ void updateGMatrix(NumericMatrix &g,
       for (int s = 0; s < periods.size() - 1; s++) {
         position += periods[s];
         bPos += periods[s];
+        gammaBoldMat(0, bPos) = gamma[s + 1];
         g(position, 0) = gamma[s + 1];
       }
     }


### PR DESCRIPTION
updateGMatrix() only wrote the first seasonal smoothing parameter into the gamma.bold matrix, leaving the entries for the remaining seasonal periods at their initial values