### PR TITLE
fix(meanf): handle single confidence level with bootstrap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `bld.mbb.bootstrap()` no longer errors when `num = 1` and now validates that `num` is a positive integer.
 * `forecast.Arima()` now correctly passes `xreg` when `bootstrap = TRUE` (#1115).
 * `forecast.ets()` now gives the intended error message when forecasting fails for a multiplicative trend model.
+* `meanf()` no longer errors with `bootstrap = TRUE` when a single confidence level is supplied.
 * `nsdiffs()` now ignores extra arguments passed via `...` with `test = "seas"` instead of silently returning 0.
 * `print()` for `Arima()` models now displays the stored AICc and BIC values instead of recomputing them, which gave slightly different results for series with interior missing values.
 * `theta_model()` and `thetaf()` gained a `type` argument to select additive or multiplicative seasonal decomposition.

--- a/R/mean.R
+++ b/R/mean.R
@@ -119,8 +119,15 @@ forecast.mean_model <- function(
       nrow = h
     )
     sim <- sweep(sim, 1, f, "+")
-    lower <- t(apply(sim, 1, quantile, prob = .5 - level / 200))
-    upper <- t(apply(sim, 1, quantile, prob = .5 + level / 200))
+    lower <- apply(sim, 1, quantile, prob = .5 - level / 200)
+    upper <- apply(sim, 1, quantile, prob = .5 + level / 200)
+    if (nconf > 1L) {
+      lower <- t(lower)
+      upper <- t(upper)
+    } else {
+      lower <- matrix(lower, ncol = 1)
+      upper <- matrix(upper, ncol = 1)
+    }
   } else {
     lower <- upper <- matrix(NA_real_, nrow = h, ncol = nconf)
     for (i in seq_len(nconf)) {


### PR DESCRIPTION
now follows the simulate_forecast() pattern to work for a single conf level